### PR TITLE
Correctly copy modes buffer into request while configuring pty

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -1185,7 +1185,7 @@ SSH2Stream.prototype.pty = function(chan, rows, cols, height,
     for (var i = 0; i < modesLen; ++i)
       buf[p++] = modes[i];
   } else if (Buffer.isBuffer(modes))
-    modes.copy(buf, 0, p);
+    modes.copy(buf, p);
   else if (typeof modes === 'string')
     buf.write(modes, p += 4, modesLen, 'binary');
 


### PR DESCRIPTION
I was able to replicate this issue: https://github.com/mscdex/ssh2/issues/239

It appears the problem is a malformed pty-req request, which causes some ssh servers to terminate the connection roughly. 

Requests were randomly malformed, because SSH2Stream.pty was not correctly copying the 'modes' buffer into the request buffer. Instead, whatever junk was already present in that position of the request buffer was sent as the modes list. 