### PR TITLE
Remember the authMethod when acting as a server, to dispatch auth messages

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -3563,6 +3563,11 @@ function parsePacket(self, callback) {
                + method
                + ')');
 
+    // XXX: This should be a stack of USERAUTH_REQUESTs that we've seen
+    // because RFC4252 says "The client MAY send several authentication
+    // requests without waiting for responses from previous requests."
+    self._state.authMethod = method;
+
     self.emit('USERAUTH_REQUEST', username, svcName, method, methodData);
   } else if (type === MESSAGE.USERAUTH_SUCCESS) {
     /*


### PR DESCRIPTION
There are several USERAUTH messages that all use the same type 60:

  USERAUTH_PASSWD_CHANGEREQ: If in "password" userauth
  USERAUTH_PK_OK: If in "publickey" userauth
  USERAUTH_INFO_REQUEST: If in "keyboard-interactive" userauth

If a packet with type 60 is seen, it needs to be interpreted appropriately
based on what kind of USERAUTH_REQUEST it is in response to.  When using
the ssh2-stream as a client, calls to auth* update the authMethod state
appropriately before sending the USERAUTH_REQUEST packet.  So, when
acting as a server, we must remember this state when we parse a
USERAUTH_REQUEST packet from a client.

However, it isn't enough to just set the state variable: a client may send
multiple USERAUTH_REQUESTs of different types at the same time, so our
rules for dispatching must be more stateful: leave a note to that effect.