### PR TITLE
fix verification of truncated ("-96") hmacs.

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -4395,7 +4395,7 @@ function hmacVerify(self, data) {
     calcHmac.update(hmac.bufCompute);
     calcHmac.update(instate.packet);
 
-    return (calcHmac.digest('binary') === data.toString('binary'));
+    return (calcHmac.digest('binary').slice(0, instate.hmac.size) === data.toString('binary'));
   }
 }
 
@@ -4892,11 +4892,7 @@ function send(self, payload, cb, bypass) {
     outstate.bufSeqno.writeUInt32BE(outstate.seqno, 0, true);
     mac.update(outstate.bufSeqno);
     mac.update(buf);
-    mac = mac.digest('binary');
-    if (hmac.type.length > 3 && hmac.type.substr(-3) === '-96') {
-      // only keep 96 bits of hash
-      mac = new Buffer(mac, 'binary').toString('binary', 0, 96 / 8);
-    }
+    mac = mac.digest('binary').slice(0, outstate.hmac.size);
     mac = new Buffer(mac, 'binary');
   }
 

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -4396,7 +4396,9 @@ function hmacVerify(self, data) {
     calcHmac.update(instate.packet);
 
     var mac = calcHmac.digest('binary');
-    if (mac.length > instate.hmac.size) mac = mac.slice(0, instate.hmac.size);
+    if (mac.length > instate.hmac.size) {
+      mac = mac.slice(0, instate.hmac.size);
+    }
     return (mac === data.toString('binary'));
   }
 }
@@ -4895,7 +4897,9 @@ function send(self, payload, cb, bypass) {
     mac.update(outstate.bufSeqno);
     mac.update(buf);
     mac = mac.digest('binary');
-    if (mac.length > outstate.hmac.size) mac = mac.slice(0, outstate.hmac.size);
+    if (mac.length > outstate.hmac.size) {
+      mac = mac.slice(0, outstate.hmac.size);
+    }
     mac = new Buffer(mac, 'binary');
   }
 

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -4395,7 +4395,9 @@ function hmacVerify(self, data) {
     calcHmac.update(hmac.bufCompute);
     calcHmac.update(instate.packet);
 
-    return (calcHmac.digest('binary').slice(0, instate.hmac.size) === data.toString('binary'));
+    var mac = calcHmac.digest('binary');
+    if (mac.length > instate.hmac.size) mac = mac.slice(0, instate.hmac.size);
+    return (mac === data.toString('binary'));
   }
 }
 
@@ -4892,7 +4894,8 @@ function send(self, payload, cb, bypass) {
     outstate.bufSeqno.writeUInt32BE(outstate.seqno, 0, true);
     mac.update(outstate.bufSeqno);
     mac.update(buf);
-    mac = mac.digest('binary').slice(0, outstate.hmac.size);
+    mac = mac.digest('binary');
+    if (mac.length > outstate.hmac.size) mac = mac.slice(0, outstate.hmac.size);
     mac = new Buffer(mac, 'binary');
   }
 


### PR DESCRIPTION
computed HMACs weren't being truncated to `hmac.size` during packet verification, so it would reject valid packets.

i noticed this on an android ssh client that likes "hmac-sha1-96", but you can reproduce the bug by commenting out the HMACs around line 196 of constants.js, leaving only the last two with "-96".

output packets were fine for now (they were special-cased to the 96 case), but i changed the code to be the same each way, in case other hmac lengths are supported.
