### PR TITLE
Send terminal modes in pty()

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -4449,7 +4449,7 @@ function modesToBytes(modes) {
     key = keys[i];
     opcode = TERMINAL_MODE[key];
     if (opcode
-        && !RE_IS_NUM.test(opcode)
+        && !RE_IS_NUM.test(key)
         && typeof modes[key] === 'number'
         && key !== 'TTY_OP_END') {
       val = modes[key];


### PR DESCRIPTION
Even if terminal modes are specified for a call to SSH2Stream.pty(),
they are never written on the wire.

modesToBytes tests "!RE_IS_NUM.test(opcode)".  In the happy path, this
is always true: we looked up the name (key) in TERMINAL_MODE, and got
back an integer (it is a known terminal mode), or undefined (unknown).

We want to check !RE_IS_NUM.test(key) instead: if the key was a number,
then we looked up a number in TERMINAL_MODE, rather than a mode string.