### PR TITLE
SSH2Stream: Fix host key algorithm selection in server mode

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -2110,14 +2110,16 @@ function check_KEXINIT(self, init) {
   var kex_algorithm = clientList[i];
   debug('DEBUG: KEX algorithm: ' + kex_algorithm);
 
-  debug('DEBUG: (local) Host key formats: ' + ALGORITHMS.SERVER_HOST_KEY);
-  debug('DEBUG: (remote) Host key formats: ' + init.algorithms.srvHostKey);
   if (self.server) {
-    serverList = ALGORITHMS.SERVER_HOST_KEY;
+    serverList = self.config.publicKey.fulltype;
     clientList = init.algorithms.srvHostKey;
+    debug('DEBUG: (local) Host key formats: ' + serverList);
+    debug('DEBUG: (remote) Host key formats: ' + clientList);
   } else {
     serverList = init.algorithms.srvHostKey;
     clientList = ALGORITHMS.SERVER_HOST_KEY;
+    debug('DEBUG: (local) Host key formats: ' + clientList);
+    debug('DEBUG: (remote) Host key formats: ' + serverList);
   }
   // check for agreeable server host key format
   for (i = 0, len = clientList.length;


### PR DESCRIPTION
Host key algorithm was not being selected based on user's configured privateKeys
in server mode.