### PR TITLE
parseKey appended comments in parsed public key output

### DIFF
--- a/lib/keyParser.js
+++ b/lib/keyParser.js
@@ -6,7 +6,7 @@ var utils;
 var RE_PPK = /^PuTTY-User-Key-File-2: ssh-(rsa|dss)\r?\nEncryption: (aes256-cbc|none)\r?\nComment: ([^\r\n]*)\r?\nPublic-Lines: \d+\r?\n([\s\S]+?)\r?\nPrivate-Lines: \d+\r?\n([\s\S]+?)\r?\nPrivate-MAC: ([^\r\n]+)/,
     RE_HEADER_OPENSSH_PRIV = /^-----BEGIN (RSA|DSA) PRIVATE KEY-----$/i,
     RE_FOOTER_OPENSSH_PRIV = /^-----END (?:RSA|DSA) PRIVATE KEY-----$/i,
-    RE_HEADER_OPENSSH_PUB = /^(ssh-(rsa|dss)(?:-cert-v0[01]@openssh.com)?) ([A-Z0-9a-z\/+=]+(?:$|\s+([\S].*)?)$)/i,
+    RE_HEADER_OPENSSH_PUB = /^(ssh-(rsa|dss)(?:-cert-v0[01]@openssh.com)?) ([A-Z0-9a-z\/+=]+)(?:$|\s+([\S].*)?)$/i,
     RE_HEADER_RFC4716_PUB = /^---- BEGIN SSH2 PUBLIC KEY ----$/i,
     RE_FOOTER_RFC4716_PUB = /^---- END SSH2 PUBLIC KEY ----$/i,
     RE_HEADER_OPENSSH = /^([^:]+):\s*([\S].*)?$/i,


### PR DESCRIPTION
Changed `RE_HEADER_OPENSSH_PUB` regexp to avoid that parseKey appended comments in parsed public key output.