### PR TITLE
Try to negotiate SFTP protocol version

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -289,7 +289,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
         version = state.version = readInt(buffer, 0, this, callback);
         if (version === false)
           return;
-        if (version !== 3) {
+        if (version < 3) {
           this._cleanup();
           return callback(new Error('Incompatible SFTP version: ' + version));
         } else if (server)


### PR DESCRIPTION
Specs allows client and server negotiate protocol version: client tells own max version, server answers with own, and client either accepts max of those, or rejects connection.
Current implementation of server expects client to start negotiating with version 3, and rejects connection if version string is anything else. New implementation rejects connection only if client asks version below 3