### PR TITLE
sftp server name truncation bug

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -2204,8 +2204,10 @@ SFTPStream.prototype.name = function(id, names) {
       nameAttrs = attrsToBytes(name.attrs);
       namesLen += 4 + nameAttrs.nbytes;
       attrs.push(nameAttrs);
-    } else
+    } else {
+      namesLen += 4;
       attrs.push(null);
+    }
   }
 
   buf = new Buffer(4 + 1 + 4 + 4 + namesLen);


### PR DESCRIPTION
The buffer length is miscalculated as it does not take into account that even for empty attribute flags the flags are still sent.

For those needing a quick work around, attrs: {} might work but I have not tested it. Otherwise you can create dummy attrs.