### PR TITLE
FIX: correct highWaterMark default issue for large sftp downloads.

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -2564,7 +2564,8 @@ function ReadStream(sftp, path, options) {
 
   // a little bit bigger buffer and water marks by default
   if (options.highWaterMark === undefined)
-    options.highWaterMark = 64 * 1024;
+  	//-- note: it must be at or under 65535, not 65536 - http://tinyurl.com/Why65535
+    options.highWaterMark = 64 * 1024 - 1;
 
   ReadableStream.call(this, options);
 


### PR DESCRIPTION
High level, this fix addresses an issue where when downloading a large file
(greater than 65535 bytes), the 65536th byte is dropped on each buffer)
Meaning zips - etc cannot be opened.

The highest number should be 65535 not 65536.
The reason is that we are dealing with unsigned digits
and 65535 in binary is 0b1111111111111111
(this is the full integer with all 1s)

65536 in binary is just one more 0b10000000000000000

When downloading large files, what happens is that the buffer
THINKs it stores 65536 bytes, but actually only stores 65535
(and the 65536th byte is lost for each buffer)

Correcting the issue to 64*1024-1 (65535) makes sure that the
highest number of bytes actually meets what it can store.
