### PR TITLE
FIX: update sftp after changes in latest nodejs constants

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -3,7 +3,7 @@
 var TransformStream = require('stream').Transform;
 var ReadableStream = require('stream').Readable;
 var WritableStream = require('stream').Writable;
-var constants = process.binding('constants');
+var constants = require('fs').constants || process.binding('constants');
 var util = require('util');
 var inherits = util.inherits;
 var isDate = util.isDate;


### PR DESCRIPTION
Reference to Node.js constants are broken since Node.js version 6.3.0 after [#6534](https://github.com/nodejs/node/pull/6534). Here's an illustration of the problem:

```bash
# Node v6.2.0
[ `node -e "process.binding('constants').S_IFMT" -p` -eq '61440' ]
# Node v6.3.0
[ `node -e "process.binding('constants').fs.S_IFMT" -p` -eq '61440' ]
```

The proposed pull request fix it in a backward compatible way.