### PR TITLE
add all RFC status codes with description

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -21,6 +21,7 @@ var ATTR = {
   EXTENDED: 0x80000000
 };
 
+// https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-9.1
 var STATUS_CODE = {
   OK: 0,
   EOF: 1,
@@ -30,22 +31,72 @@ var STATUS_CODE = {
   BAD_MESSAGE: 5,
   NO_CONNECTION: 6,
   CONNECTION_LOST: 7,
-  OP_UNSUPPORTED: 8
+  OP_UNSUPPORTED: 8,
+  INVALID_HANDLE: 9,
+  NO_SUCH_PATH: 10,
+  FILE_ALREADY_EXISTS: 11,
+  WRITE_PROTECT: 12,
+  NO_MEDIA: 13,
+  NO_SPACE_ON_FILESYSTEM: 14,
+  QUOTA_EXCEEDED: 15,
+  UNKNOWN_PRINCIPAL: 16,
+  LOCK_CONFLICT: 17,
+  DIR_NOT_EMPTY: 18,
+  NOT_A_DIRECTORY: 19,
+  INVALID_FILENAME: 20,
+  LINK_LOOP: 21,
+  CANNOT_DELETE: 22,
+  INVALID_PARAMETER: 23,
+  FILE_IS_A_DIRECTORY: 24,
+  BYTE_RANGE_LOCK_CONFLICT: 25,
+  BYTE_RANGE_LOCK_REFUSED: 26,
+  DELETE_PENDING: 27,
+  FILE_CORRUPT: 28,
+  OWNER_INVALID: 29,
+  GROUP_INVALID: 30,
+  NO_MATCHING_BYTE_RANGE_LOCK: 31,
 };
 Object.keys(STATUS_CODE).forEach(function(key) {
   STATUS_CODE[STATUS_CODE[key]] = key;
 });
 var STATUS_CODE_STR = {
-  0: 'No error',
-  1: 'End of file',
-  2: 'No such file or directory',
-  3: 'Permission denied',
-  4: 'Failure',
-  5: 'Bad message',
-  6: 'No connection',
-  7: 'Connection lost',
-  8: 'Operation unsupported'
+  OK: 'Indicates successful completion of the operation.',
+  EOF: 'An attempt to read past the end-of-file was made.',
+  NO_SUCH_FILE: 'A reference was made to a file which does not exist.',
+  PERMISSION_DENIED: 'The user does not have sufficient permissions to perform the operation.',
+  FAILURE: 'An error occurred, but no specific error code exists to describe the failure.',
+  BAD_MESSAGE: 'A badly formatted packet or other SFTP protocol incompatibility was detected.',
+  NO_CONNECTION: 'There is no connection to the server.',
+  CONNECTION_LOST: 'The connection to the server was lost.',
+  OP_UNSUPPORTED: 'An attempted operation could not be completed by the server because the server does not support the operation.',
+  INVALID_HANDLE: 'The handle value was invalid.',
+  NO_SUCH_PATH: 'The file path does not exist or is invalid.',
+  FILE_ALREADY_EXISTS: 'The file already exists.',
+  WRITE_PROTECT: 'The file is on read-only media, or the media is write protected.',
+  NO_MEDIA: 'The requested operation cannot be completed because there is no media available in the drive.',
+  NO_SPACE_ON_FILESYSTEM: 'The requested operation cannot be completed because there is insufficient free space on the filesystem.',
+  QUOTA_EXCEEDED: 'The operation cannot be completed because it would exceed the user\'s storage quota.',
+  UNKNOWN_PRINCIPAL: 'A principal referenced by the request was unknown.',
+  LOCK_CONFLICT: 'The file could not be opened because it is locked by another process.',
+  DIR_NOT_EMPTY: 'The directory is not empty.',
+  NOT_A_DIRECTORY: 'The specified file is not a directory.',
+  INVALID_FILENAME: 'The filename is not valid.',
+  LINK_LOOP: 'Too many symbolic links encountered.',
+  CANNOT_DELETE: 'The file cannot be deleted.',
+  INVALID_PARAMETER: 'One of the parameters was out of range, or the parameters specified cannot be used together.',
+  FILE_IS_A_DIRECTORY: 'The specified file was a directory in a context where a directory cannot be used.',
+  BYTE_RANGE_LOCK_CONFLICT: 'An read or write operation failed because another process\'s mandatory byte-range lock overlaps with the request.',
+  BYTE_RANGE_LOCK_REFUSED: 'A request for a byte range lock was refused.',
+  DELETE_PENDING: 'An operation was attempted on a file for which a delete operation is pending.',
+  FILE_CORRUPT: 'The file is corrupt; an filesystem integrity check should be run.',
+  OWNER_INVALID: 'The principal specified can not be assigned as an owner of a file.',
+  GROUP_INVALID: 'The principal specified can not be assigned as the primary group of a file.',
+  NO_MATCHING_BYTE_RANGE_LOCK: 'The requested operation could not be completed because the specified byte range lock has not been granted.',
 };
+Object.keys(STATUS_CODE_STR).forEach(function(key) {
+  STATUS_CODE_STR[STATUS_CODE[key]] = STATUS_CODE_STR[key];
+});
+SFTPStream.STATUS_CODE_STR = STATUS_CODE_STR;
 SFTPStream.STATUS_CODE = STATUS_CODE;
 
 var REQUEST = {
@@ -2890,4 +2941,3 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 
 
 module.exports = SFTPStream;
-

--- a/test/test-sftp.js
+++ b/test/test-sftp.js
@@ -773,7 +773,7 @@ var tests = [
           server.end();
         });
         var buf = [];
-        client.createReadStream(path_).on('readable', function() { 
+        client.createReadStream(path_).on('readable', function() {
           var chunk;
           while ((chunk = this.read()) !== null) {
             buf.push(chunk);
@@ -988,7 +988,7 @@ var tests = [
         client.open('/foo/bar', 'w', function(err, handle) {
           assert(err, 'Expected error');
           assert.strictEqual(err.code, 4);
-          assert.strictEqual(err.message, 'Failure');
+          assert.strictEqual(err.message, SFTPStream.STATUS_CODE_STR[4]);
           assert.strictEqual(err.lang, '');
           next();
         });


### PR DESCRIPTION
This PR adds all valid status codes from https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-9.1 including proper descriptions.