### PR TITLE
disconnect parsing: handle missing lang

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -3733,7 +3733,8 @@ function parsePacket(self, callback) {
     if (description === false)
       return false;
 
-    lang = readString(payload, payload._pos, 'ascii', self, callback);
+    if (payload._pos < payload.length)
+      lang = readString(payload, payload._pos, 'ascii', self, callback);
 
     self.debug('DEBUG: Parser: IN_PACKETDATAAFTER, packet: DISCONNECT ('
                + reasonText


### PR DESCRIPTION
The Perl SFTP client's disconnect message sadly omits the lang field
from the disconnect message. This patch allows it to not crash the
server.