### PR TITLE
Fix zlib@openssh compression for server

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -5361,6 +5361,14 @@ function send_(self, payload, cb) {
 
   cb && cb();
 
+  if (payload === USERAUTH_SUCCESS_PACKET) {
+    var instate = state.incoming;
+    if (outstate.compress.type === 'zlib@openssh.com')
+      outstate.compress.instance = zlib.createDeflate(ZLIB_OPTS);
+    if (instate.decompress.type === 'zlib@openssh.com')
+      instate.decompress.instance = zlib.createInflate(ZLIB_OPTS);
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
Hello,

I discovered that `zlib@openssh` compression support is broken in ssh2 server.
Looks like compression is activating only in case of incoming `USERAUTH_SUCCESS` message, not the outgoing one.
This PR is an attempt to fix this behaviour, I tested this and it works for me.

Unfortunately I have no much time to dig into ssh2/ssh2-streams source code and propose better solution, so this is just a proof of concept, so maybe someone would suggest a better way to fix address this bug.

Thanks.