### PR TITLE
added proper cleanup for fastXfer if the sftp stream has ended

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 
 var readString = require('./utils').readString;
 var readInt = require('./utils').readInt;
+var fastXferInstances = []
 
 var ATTR = {
   SIZE: 0x00000001,
@@ -165,6 +166,18 @@ function SFTPStream(cfg, remoteIdentRaw) {
   function onFinish() {
     self.writable = false;
     self._cleanup(false);
+    // cleanup fastxfer
+    for (var i = 0; i < fastXferInstances.length; i++) {
+      var fastxfer = fastXferInstances[i]
+      if(fastxfer.srcHandle){
+        fastxfer.src.close(fastxfer.srcHandle)
+        fastxfer.srcHandle = null
+      }
+      if(fastxfer.dstHandle){
+        fastxfer.dst.close(fastxfer.dstHandle)
+        fastxfer.dstHandle = null
+      }
+    }
   }
 
   if (!this.server)
@@ -979,6 +992,10 @@ function tryCreateBuffer(size) {
   }
 }
 function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+  var self = this
+  self.src = src
+  self.dst = dst
+
   var concurrency = 64;
   var chunkSize = 32768;
   //var preserve = false;
@@ -1011,8 +1028,6 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
   var reads = 0;
   var total = 0;
   var hadError = false;
-  var srcHandle;
-  var dstHandle;
   var readbuf;
   var bufsize = chunkSize * concurrency;
 
@@ -1025,19 +1040,23 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
     var left = 0;
     var cbfinal;
 
-    if (srcHandle || dstHandle) {
+    if (self.srcHandle || self.dstHandle) {
       cbfinal = function() {
         if (--left === 0)
           cb(err);
       };
-      if (srcHandle && (src === fs || src.writable))
+      if (self.srcHandle && (src === fs || src.writable))
         ++left;
-      if (dstHandle && (dst === fs || dst.writable))
+      if (self.dstHandle && (dst === fs || dst.writable))
         ++left;
-      if (srcHandle && (src === fs || src.writable))
-        src.close(srcHandle, cbfinal);
-      if (dstHandle && (dst === fs || dst.writable))
-        dst.close(dstHandle, cbfinal);
+      if (self.srcHandle && (src === fs || src.writable)){
+        src.close(self.srcHandle, cbfinal);
+        self.srcHandle = null
+      }
+      if (self.dstHandle && (dst === fs || dst.writable)){
+        dst.close(self.dstHandle, cbfinal);
+        self.dstHandle = null
+      }
     } else
       cb(err);
   }
@@ -1046,9 +1065,9 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
     if (err)
       return onerror(err);
 
-    srcHandle = sourceHandle;
+    self.srcHandle = sourceHandle;
 
-    src.fstat(srcHandle, function tryStat(err, attrs) {
+    src.fstat(self.srcHandle, function tryStat(err, attrs) {
       if (err) {
         if (src !== fs) {
           // Try stat() for sftp servers that may not support fstat() for
@@ -1068,7 +1087,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
         if (err)
           return onerror(err);
 
-        dstHandle = destHandle;
+        self.dstHandle = destHandle;
 
         if (fsize <= 0)
           return onerror();
@@ -1088,7 +1107,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
           return onerror(readbuf);
 
         if (mode !== undefined) {
-          dst.fchmod(dstHandle, mode, function tryAgain(err) {
+          dst.fchmod(self.dstHandle, mode, function tryAgain(err) {
             if (err) {
               // Try chmod() for sftp servers that may not support fchmod() for
               // whatever reason
@@ -1108,9 +1127,9 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
             return onerror(err);
 
           if (src === fs)
-            dst.writeData(dstHandle, data, datapos || 0, nb, dstpos, writeCb);
+            dst.writeData(self.dstHandle, data, datapos || 0, nb, dstpos, writeCb);
           else
-            dst.write(dstHandle, data, datapos || 0, nb, dstpos, writeCb);
+            dst.write(self.dstHandle, data, datapos || 0, nb, dstpos, writeCb);
 
           function writeCb(err) {
             if (err)
@@ -1121,12 +1140,12 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
 
             if (--reads === 0) {
               if (total === fsize) {
-                dst.close(dstHandle, function(err) {
-                  dstHandle = undefined;
+                dst.close(self.dstHandle, function(err) {
+                  self.dstHandle = undefined;
                   if (err)
                     return onerror(err);
-                  src.close(srcHandle, function(err) {
-                    srcHandle = undefined;
+                  src.close(self.srcHandle, function(err) {
+                    self.srcHandle = undefined;
                     if (err)
                       return onerror(err);
                     cb();
@@ -1148,14 +1167,14 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
           while (pdst < fsize && reads < concurrency) {
             chunk = (pdst + chunkSize > fsize ? fsize - pdst : chunkSize);
             if (src === fs) {
-              src.read(srcHandle,
+              src.read(self.srcHandle,
                        readbuf,
                        psrc,
                        chunk,
                        pdst,
                        makeCb(psrc, pdst));
             } else
-              src.readData(srcHandle, readbuf, psrc, chunk, pdst, onread);
+              src.readData(self.srcHandle, readbuf, psrc, chunk, pdst, onread);
             psrc += chunk;
             pdst += chunk;
             ++reads;
@@ -1170,13 +1189,13 @@ SFTPStream.prototype.fastGet = function(remotePath, localPath, opts, cb) {
   if (this.server)
     throw new Error('Client-only method called in server mode');
 
-  fastXfer(this, fs, remotePath, localPath, opts, cb);
+  fastXferInstances.push(new fastXfer(this, fs, remotePath, localPath, opts, cb));
 };
 SFTPStream.prototype.fastPut = function(localPath, remotePath, opts, cb) {
   if (this.server)
     throw new Error('Client-only method called in server mode');
 
-  fastXfer(fs, this, localPath, remotePath, opts, cb);
+  fastXferInstances.push(fastXfer(fs, this, localPath, remotePath, opts, cb));
 };
 SFTPStream.prototype.readFile = function(path, options, callback_) {
   if (this.server)

--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -1195,7 +1195,7 @@ SFTPStream.prototype.fastPut = function(localPath, remotePath, opts, cb) {
   if (this.server)
     throw new Error('Client-only method called in server mode');
 
-  fastXferInstances.push(fastXfer(fs, this, localPath, remotePath, opts, cb));
+  fastXferInstances.push(new fastXfer(fs, this, localPath, remotePath, opts, cb));
 };
 SFTPStream.prototype.readFile = function(path, options, callback_) {
   if (this.server)


### PR DESCRIPTION
If the sftpstream end for some reason (disconnect or something else) than the fastXfer process will block the files that are in progress.

So if you download a file with fastGet and hard-kill the stream during that process, the processed files are stalled/zombie and cannot be accessed anymore, until you stop the running node process.

This pull request add a proper cleanup for the fastXfer handles, when the stream ends for some reason so that the file handles get properly closed.