### PR TITLE
bugfix-72: Trimmed the stream identifier string to avoid crash

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -133,7 +133,7 @@ function SSH2Stream(cfg) {
     // Client/Server
     ident: 'SSH-2.0-'
            + (cfg.ident
-              || ('ssh2js' + MODULE_VER + (this.server ? 'srv' : ''))),
+              || ('ssh2js' + MODULE_VER + (this.server ? 'srv' : ''))).trim(),
     algorithms: {
       kex: ALGORITHMS.KEX,
       kexBuf: ALGORITHMS.KEX_BUF,


### PR DESCRIPTION
a simple fix for [issue 72](https://github.com/mscdex/ssh2-streams/issues/72)