### PR TITLE
Fix: off-by-one bug handling bad_pkt 

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -310,8 +310,8 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
         }
 
         if (status === 'bad_pkt') {
-          // copy original packet info
-          pktHdrBuf.writeUInt32BE(pktLeft, 0, true);
+          // Copy original packet info to left of pktHdrBuf
+          pktHdrBuf.writeUInt32BE(pktLeft + 1, 0, true);
           pktHdrBuf[4] = pktType;
 
           pktLeft = 4;

--- a/test/test-sftp.js
+++ b/test/test-sftp.js
@@ -1168,6 +1168,35 @@ var tests = [
     },
     what: 'End SFTP stream on bad handshake (server)'
   },
+  { run: function() {
+      setup(this);
+
+      var self = this;
+      var what = this.what;
+      var client = this.client;
+      client._state.extensions['statvfs@openssh.com'] = ['2'];
+
+      this.onReady = function() {
+        var pathOne_ = '/foo/baz';
+        client.ext_openssh_statvfs(pathOne_, function(err, fsInfo) {
+          assert(++self.state.responses === 1,
+                 makeMsg(what, 'Saw too many responses'));
+          assert(err && err.code === STATUS_CODE.OP_UNSUPPORTED,
+                 makeMsg(what, 'Expected OP_UNSUPPORTED, got: ' + err));
+
+          var pathTwo_ = '/baz/foo';
+          client.ext_openssh_statvfs(pathTwo_, function(err, fsInfo) {
+            assert(++self.state.responses === 2,
+                   makeMsg(what, 'Saw too many responses'));
+            assert(err && err.code === STATUS_CODE.OP_UNSUPPORTED,
+                   makeMsg(what, 'Expected OP_UNSUPPORTED, got: ' + err));
+            next();
+          });
+        });
+      };
+    },
+    what: 'multiple extended operations in sequence fail as expected'
+  },
 ];
 
 function setup(self) {


### PR DESCRIPTION
Proposed solution to https://github.com/mscdex/ssh2-streams/issues/79

In https://github.com/mscdex/ssh2-streams/blob/master/lib/sftp.js#L275 we subtract 1 from packet header length field to account for type byte. However, when handling the `bad_pkt` condition, we omit to add 1 back to header length field when copying header to front of `pktHdrBuf` (https://github.com/mscdex/ssh2-streams/blob/master/lib/sftp.js#L314), resulting in corruption of the packet header.