### PR TITLE
SFTPstream open flags: add int support

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -774,7 +774,7 @@ SFTPStream.prototype.open = function(path, flags_, attrs, cb) {
     attrs = undefined;
   }
 
-  var flags = stringToFlags(flags_);
+  var flags = typeof flags_ === 'number' ? flags_ : stringToFlags(flags_);
   if (flags === null)
     throw new Error('Unknown flags string: ' + flags_);
 


### PR DESCRIPTION
Handle unmapped flags on SFTPstream.open by accepting flags as a Number

closes https://github.com/mscdex/ssh2-streams/issues/87 