### PR TITLE
feature: Added support for 3 new key exchanges

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -194,6 +194,9 @@ var DEFAULT_KEX = [
   'diffie-hellman-group14-sha1' // REQUIRED
 ];
 var SUPPORTED_KEX = [
+  'kexguess2@matt.ucc.asn.au',
+  'diffie-hellman-group16-sha512',
+  'curve25519-sha256@libssh.org',
   'diffie-hellman-group1-sha1'  // REQUIRED
 ];
 if (semver.gte(process.version, '0.11.12')) {


### PR DESCRIPTION
One of our devices only supports these kex after an SSH upgrade, i noticed these were not part of your library. Can this be added for future releases?