### PR TITLE
SSH2Stream: remove `noAssert` argument

### DIFF
--- a/lib/keyParser.js
+++ b/lib/keyParser.js
@@ -156,7 +156,7 @@ module.exports = function(data) {
       }
       ret.public = new Buffer(data.slice(i, -1).join(''), 'base64');
     }
-    len = ret.public.readUInt32BE(0, true);
+    len = ret.public.readUInt32BE(0);
     var fulltype = ret.public.toString('ascii', 4, 4 + len);
     ret.fulltype = fulltype;
     if (fulltype === 'ssh-dss')

--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -272,7 +272,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
         pktBuf = pktHdrBuf;
       } else {
         // here we read the right-most 5 bytes from buffer (pktHdrBuf)
-        pktLeft = buffer.readUInt32BE(4, true) - 1; // account for type byte
+        pktLeft = buffer.readUInt32BE(4) - 1; // account for type byte
         pktType = buffer[8];
 
         if (server) {
@@ -311,7 +311,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
 
         if (status === 'bad_pkt') {
           // copy original packet info
-          pktHdrBuf.writeUInt32BE(pktLeft, 0, true);
+          pktHdrBuf.writeUInt32BE(pktLeft, 0);
           pktHdrBuf[4] = pktType;
 
           pktLeft = 4;
@@ -434,7 +434,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
                 var reqBufLen = req.buffer.length;
                 if (dataLen > reqBufLen) {
                   // truncate response data to fit expected size
-                  buffer.writeUInt32BE(reqBufLen, 4, true);
+                  buffer.writeUInt32BE(reqBufLen, 4);
                 }
                 data = readString(buffer, 4, req.buffer, this, callback);
                 if (data === false)
@@ -732,7 +732,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
 
       // by this point we have already read the type byte and the id bytes, so
       // we subtract those from the number of bytes to skip
-      pktLeft = buffer.readUInt32BE(0, true) - 5;
+      pktLeft = buffer.readUInt32BE(0) - 5;
 
       status = 'discard';
     }
@@ -800,15 +800,15 @@ SFTPStream.prototype.open = function(path, flags_, attrs, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen + 4 + 4 + attrBytes);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.OPEN;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
-  buf.writeUInt32BE(flags, p += pathlen, true);
-  buf.writeUInt32BE(attrFlags, p += 4, true);
+  buf.writeUInt32BE(flags, p += pathlen);
+  buf.writeUInt32BE(attrFlags, p += 4);
   if (attrs && attrFlags) {
     p += 4;
     for (var i = 0, len = attrs.length; i < len; ++i)
@@ -836,12 +836,12 @@ SFTPStream.prototype.close = function(handle, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + handlelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.CLOSE;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(handlelen, p, true);
+  buf.writeUInt32BE(handlelen, p);
   handle.copy(buf, p += 4);
 
   state.requests[reqid] = { cb: cb };
@@ -876,19 +876,19 @@ SFTPStream.prototype.readData = function(handle, buf, off, len, position, cb) {
   var pos = position;
   var out = new Buffer(4 + 1 + 4 + 4 + handlelen + 8 + 4);
 
-  out.writeUInt32BE(out.length - 4, 0, true);
+  out.writeUInt32BE(out.length - 4, 0);
   out[4] = REQUEST.READ;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  out.writeUInt32BE(reqid, 5, true);
+  out.writeUInt32BE(reqid, 5);
 
-  out.writeUInt32BE(handlelen, p, true);
+  out.writeUInt32BE(handlelen, p);
   handle.copy(out, p += 4);
   p += handlelen;
   for (var i = 7; i >= 0; --i) {
     out[p + i] = pos & 0xFF;
     pos /= 256;
   }
-  out.writeUInt32BE(len, p += 8, true);
+  out.writeUInt32BE(len, p += 8);
 
   state.requests[reqid] = {
     cb: function(err, data, nb) {
@@ -942,19 +942,19 @@ SFTPStream.prototype.writeData = function(handle, buf, off, len, position, cb) {
   var p = 9;
   var out = new Buffer(4 + 1 + 4 + 4 + handlelen + 8 + 4 + len);
 
-  out.writeUInt32BE(out.length - 4, 0, true);
+  out.writeUInt32BE(out.length - 4, 0);
   out[4] = REQUEST.WRITE;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  out.writeUInt32BE(reqid, 5, true);
+  out.writeUInt32BE(reqid, 5);
 
-  out.writeUInt32BE(handlelen, p, true);
+  out.writeUInt32BE(handlelen, p);
   handle.copy(out, p += 4);
   p += handlelen;
   for (var i = 7; i >= 0; --i) {
     out[p + i] = position & 0xFF;
     position /= 256;
   }
-  out.writeUInt32BE(len, p += 8, true);
+  out.writeUInt32BE(len, p += 8);
   buf.copy(out, p += 4, off, off + len);
 
   state.requests[reqid] = {
@@ -1427,12 +1427,12 @@ SFTPStream.prototype.unlink = function(filename, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + fnamelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.REMOVE;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(fnamelen, p, true);
+  buf.writeUInt32BE(fnamelen, p);
   buf.write(filename, p += 4, fnamelen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1456,14 +1456,14 @@ SFTPStream.prototype.rename = function(oldPath, newPath, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + oldlen + 4 + newlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.RENAME;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(oldlen, p, true);
+  buf.writeUInt32BE(oldlen, p);
   buf.write(oldPath, p += 4, oldlen, 'utf8');
-  buf.writeUInt32BE(newlen, p += oldlen, true);
+  buf.writeUInt32BE(newlen, p += oldlen);
   buf.write(newPath, p += 4, newlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1499,12 +1499,12 @@ SFTPStream.prototype.mkdir = function(path, attrs, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen + 4 + attrBytes);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.MKDIR;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
   buf.writeUInt32BE(flags, p += pathlen);
   if (flags) {
@@ -1533,12 +1533,12 @@ SFTPStream.prototype.rmdir = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.RMDIR;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1605,12 +1605,12 @@ SFTPStream.prototype.readdir = function(where, opts, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + handlelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.READDIR;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(handlelen, p, true);
+  buf.writeUInt32BE(handlelen, p);
   where.copy(buf, p += 4);
 
   state.requests[reqid] = {
@@ -1648,12 +1648,12 @@ SFTPStream.prototype.fstat = function(handle, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + handlelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.FSTAT;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(handlelen, p, true);
+  buf.writeUInt32BE(handlelen, p);
   handle.copy(buf, p += 4);
 
   state.requests[reqid] = { cb: cb };
@@ -1675,12 +1675,12 @@ SFTPStream.prototype.stat = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.STAT;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1702,12 +1702,12 @@ SFTPStream.prototype.lstat = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.LSTAT;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1729,12 +1729,12 @@ SFTPStream.prototype.opendir = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.OPENDIR;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -1767,12 +1767,12 @@ SFTPStream.prototype.setstat = function(path, attrs, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen + 4 + attrBytes);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.SETSTAT;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
   buf.writeUInt32BE(flags, p += pathlen);
   if (flags) {
@@ -1814,12 +1814,12 @@ SFTPStream.prototype.fsetstat = function(handle, attrs, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + handlelen + 4 + attrBytes);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.FSETSTAT;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(handlelen, p, true);
+  buf.writeUInt32BE(handlelen, p);
   handle.copy(buf, p += 4);
   buf.writeUInt32BE(flags, p += handlelen);
   if (flags) {
@@ -1882,12 +1882,12 @@ SFTPStream.prototype.readlink = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.READLINK;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = {
@@ -1919,21 +1919,21 @@ SFTPStream.prototype.symlink = function(targetPath, linkPath, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + linklen + 4 + targetlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.SYMLINK;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
   if (this._isOpenSSH) {
     // OpenSSH has linkpath and targetpath positions switched
-    buf.writeUInt32BE(targetlen, p, true);
+    buf.writeUInt32BE(targetlen, p);
     buf.write(targetPath, p += 4, targetlen, 'utf8');
-    buf.writeUInt32BE(linklen, p += targetlen, true);
+    buf.writeUInt32BE(linklen, p += targetlen);
     buf.write(linkPath, p += 4, linklen, 'utf8');
   } else {
-    buf.writeUInt32BE(linklen, p, true);
+    buf.writeUInt32BE(linklen, p);
     buf.write(linkPath, p += 4, linklen, 'utf8');
-    buf.writeUInt32BE(targetlen, p += linklen, true);
+    buf.writeUInt32BE(targetlen, p += linklen);
     buf.write(targetPath, p += 4, targetlen, 'utf8');
   }
 
@@ -1956,12 +1956,12 @@ SFTPStream.prototype.realpath = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.REALPATH;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
+  buf.writeUInt32BE(reqid, 5);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = {
@@ -1998,16 +1998,16 @@ SFTPStream.prototype.ext_openssh_rename = function(oldPath, newPath, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + 24 + 4 + oldlen + 4 + newlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.EXTENDED;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
-  buf.writeUInt32BE(24, p, true);
+  buf.writeUInt32BE(reqid, 5);
+  buf.writeUInt32BE(24, p);
   buf.write('posix-rename@openssh.com', p += 4, 24, 'ascii');
 
-  buf.writeUInt32BE(oldlen, p += 24, true);
+  buf.writeUInt32BE(oldlen, p += 24);
   buf.write(oldPath, p += 4, oldlen, 'utf8');
-  buf.writeUInt32BE(newlen, p += oldlen, true);
+  buf.writeUInt32BE(newlen, p += oldlen);
   buf.write(newPath, p += 4, newlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -2033,14 +2033,14 @@ SFTPStream.prototype.ext_openssh_statvfs = function(path, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + 19 + 4 + pathlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.EXTENDED;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
-  buf.writeUInt32BE(19, p, true);
+  buf.writeUInt32BE(reqid, 5);
+  buf.writeUInt32BE(19, p);
   buf.write('statvfs@openssh.com', p += 4, 19, 'ascii');
 
-  buf.writeUInt32BE(pathlen, p += 19, true);
+  buf.writeUInt32BE(pathlen, p += 19);
   buf.write(path, p += 4, pathlen, 'utf8');
 
   state.requests[reqid] = {
@@ -2071,14 +2071,14 @@ SFTPStream.prototype.ext_openssh_fstatvfs = function(handle, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + 20 + 4 + handlelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.EXTENDED;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
-  buf.writeUInt32BE(20, p, true);
+  buf.writeUInt32BE(reqid, 5);
+  buf.writeUInt32BE(20, p);
   buf.write('fstatvfs@openssh.com', p += 4, 20, 'ascii');
 
-  buf.writeUInt32BE(handlelen, p += 20, true);
+  buf.writeUInt32BE(handlelen, p += 20);
   buf.write(handle, p += 4, handlelen, 'utf8');
 
   state.requests[reqid] = {
@@ -2109,16 +2109,16 @@ SFTPStream.prototype.ext_openssh_hardlink = function(oldPath, newPath, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + 20 + 4 + oldlen + 4 + newlen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.EXTENDED;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
-  buf.writeUInt32BE(20, p, true);
+  buf.writeUInt32BE(reqid, 5);
+  buf.writeUInt32BE(20, p);
   buf.write('hardlink@openssh.com', p += 4, 20, 'ascii');
 
-  buf.writeUInt32BE(oldlen, p += 20, true);
+  buf.writeUInt32BE(oldlen, p += 20);
   buf.write(oldPath, p += 4, oldlen, 'utf8');
-  buf.writeUInt32BE(newlen, p += oldlen, true);
+  buf.writeUInt32BE(newlen, p += oldlen);
   buf.write(newPath, p += 4, newlen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -2146,14 +2146,14 @@ SFTPStream.prototype.ext_openssh_fsync = function(handle, cb) {
   var p = 9;
   var buf = new Buffer(4 + 1 + 4 + 4 + 17 + 4 + handlelen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = REQUEST.EXTENDED;
   var reqid = state.writeReqid = (state.writeReqid + 1) % MAX_REQID;
-  buf.writeUInt32BE(reqid, 5, true);
-  buf.writeUInt32BE(17, p, true);
+  buf.writeUInt32BE(reqid, 5);
+  buf.writeUInt32BE(17, p);
   buf.write('fsync@openssh.com', p += 4, 17, 'ascii');
 
-  buf.writeUInt32BE(handlelen, p += 17, true);
+  buf.writeUInt32BE(handlelen, p += 17);
   buf.write(handle, p += 4, handlelen, 'utf8');
 
   state.requests[reqid] = { cb: cb };
@@ -2177,17 +2177,17 @@ SFTPStream.prototype.status = function(id, code, message, lang) {
   var langLen = Buffer.byteLength(lang);
   var buf = new Buffer(4 + 1 + 4 + 4 + 4 + msgLen + 4 + langLen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = RESPONSE.STATUS;
-  buf.writeUInt32BE(id, 5, true);
+  buf.writeUInt32BE(id, 5);
 
-  buf.writeUInt32BE(code, 9, true);
+  buf.writeUInt32BE(code, 9);
 
-  buf.writeUInt32BE(msgLen, 13, true);
+  buf.writeUInt32BE(msgLen, 13);
   if (msgLen)
     buf.write(message, 17, msgLen, 'utf8');
 
-  buf.writeUInt32BE(langLen, 17 + msgLen, true);
+  buf.writeUInt32BE(langLen, 17 + msgLen);
   if (langLen)
     buf.write(lang, 17 + msgLen + 4, langLen, 'ascii');
 
@@ -2208,11 +2208,11 @@ SFTPStream.prototype.handle = function(id, handle) {
 
   var buf = new Buffer(4 + 1 + 4 + 4 + handleLen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = RESPONSE.HANDLE;
-  buf.writeUInt32BE(id, 5, true);
+  buf.writeUInt32BE(id, 5);
 
-  buf.writeUInt32BE(handleLen, 9, true);
+  buf.writeUInt32BE(handleLen, 9);
   if (handleLen)
     handle.copy(buf, 13);
 
@@ -2234,11 +2234,11 @@ SFTPStream.prototype.data = function(id, data, encoding) {
   var dataLen = (isBuffer ? data.length : Buffer.byteLength(data, encoding));
   var buf = new Buffer(4 + 1 + 4 + 4 + dataLen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = RESPONSE.DATA;
-  buf.writeUInt32BE(id, 5, true);
+  buf.writeUInt32BE(id, 5);
 
-  buf.writeUInt32BE(dataLen, 9, true);
+  buf.writeUInt32BE(dataLen, 9);
   if (dataLen) {
     if (isBuffer)
       data.copy(buf, 13);
@@ -2297,11 +2297,11 @@ SFTPStream.prototype.name = function(id, names) {
 
   buf = new Buffer(4 + 1 + 4 + 4 + namesLen);
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = RESPONSE.NAME;
-  buf.writeUInt32BE(id, 5, true);
+  buf.writeUInt32BE(id, 5);
 
-  buf.writeUInt32BE(count, 9, true);
+  buf.writeUInt32BE(count, 9);
 
   p = 13;
 
@@ -2312,7 +2312,7 @@ SFTPStream.prototype.name = function(id, names) {
                 ? ''
                 : name.filename);
     len = Buffer.byteLength(filename);
-    buf.writeUInt32BE(len, p, true);
+    buf.writeUInt32BE(len, p);
     p += 4;
     if (len) {
       buf.write(filename, p, len, 'utf8');
@@ -2323,7 +2323,7 @@ SFTPStream.prototype.name = function(id, names) {
                 ? ''
                 : name.longname);
     len = Buffer.byteLength(longname);
-    buf.writeUInt32BE(len, p, true);
+    buf.writeUInt32BE(len, p);
     p += 4;
     if (len) {
       buf.write(longname, p, len, 'utf8');
@@ -2332,7 +2332,7 @@ SFTPStream.prototype.name = function(id, names) {
 
     attr = attrs[i];
     if (attr) {
-      buf.writeUInt32BE(attr.flags, p, true);
+      buf.writeUInt32BE(attr.flags, p);
       p += 4;
       if (attr.flags && attr.bytes) {
         var bytes = attr.bytes;
@@ -2341,7 +2341,7 @@ SFTPStream.prototype.name = function(id, names) {
             buf[p++] = bytes[j][k];
       }
     } else {
-      buf.writeUInt32BE(0, p, true);
+      buf.writeUInt32BE(0, p);
       p += 4;
     }
   }
@@ -2360,11 +2360,11 @@ SFTPStream.prototype.attrs = function(id, attrs) {
   var buf = new Buffer(4 + 1 + 4 + 4 + info.nbytes);
   var p = 13;
 
-  buf.writeUInt32BE(buf.length - 4, 0, true);
+  buf.writeUInt32BE(buf.length - 4, 0);
   buf[4] = RESPONSE.ATTRS;
-  buf.writeUInt32BE(id, 5, true);
+  buf.writeUInt32BE(id, 5);
 
-  buf.writeUInt32BE(info.flags, 9, true);
+  buf.writeUInt32BE(info.flags, 9);
 
   if (info.flags && info.bytes) {
     var bytes = info.bytes;
@@ -2392,7 +2392,7 @@ function readAttrs(buf, p, stream, callback) {
     ...      more extended data (extended_type - extended_data pairs),
                so that number of pairs equals extended_count
   */
-  var flags = buf.readUInt32BE(p, true);
+  var flags = buf.readUInt32BE(p);
   var attrs = new Stats();
 
   p += 4;

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -817,7 +817,7 @@ SSH2Stream.prototype.disconnect = function(reason) {
 
   if (DISCONNECT_REASON[reason] === undefined)
     reason = DISCONNECT_REASON.BY_APPLICATION;
-  buf.writeUInt32BE(reason, 1, true);
+  buf.writeUInt32BE(reason, 1);
 
   this.debug('DEBUG: Outgoing: Writing DISCONNECT ('
              + DISCONNECT_REASON[reason]
@@ -867,7 +867,7 @@ SSH2Stream.prototype.channelSuccess = function(chan) {
 
   buf[0] = MESSAGE.CHANNEL_SUCCESS;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_SUCCESS (' + chan + ')');
   return send(this, buf);
@@ -878,7 +878,7 @@ SSH2Stream.prototype.channelFailure = function(chan) {
 
   buf[0] = MESSAGE.CHANNEL_FAILURE;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_FAILURE (' + chan + ')');
   return send(this, buf);
@@ -889,7 +889,7 @@ SSH2Stream.prototype.channelEOF = function(chan) {
 
   buf[0] = MESSAGE.CHANNEL_EOF;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_EOF (' + chan + ')');
   return send(this, buf);
@@ -900,7 +900,7 @@ SSH2Stream.prototype.channelClose = function(chan) {
 
   buf[0] = MESSAGE.CHANNEL_CLOSE;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_CLOSE (' + chan + ')');
   return send(this, buf);
@@ -911,9 +911,9 @@ SSH2Stream.prototype.channelWindowAdjust = function(chan, amount) {
 
   buf[0] = MESSAGE.CHANNEL_WINDOW_ADJUST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(amount, 5, true);
+  buf.writeUInt32BE(amount, 5);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_WINDOW_ADJUST ('
              + chan
@@ -929,9 +929,9 @@ SSH2Stream.prototype.channelData = function(chan, data) {
 
   buf[0] = MESSAGE.CHANNEL_DATA;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(dataLen, 5, true);
+  buf.writeUInt32BE(dataLen, 5);
   if (dataIsBuffer)
     data.copy(buf, 9);
   else
@@ -947,11 +947,11 @@ SSH2Stream.prototype.channelExtData = function(chan, data, type) {
 
   buf[0] = MESSAGE.CHANNEL_EXTENDED_DATA;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(type, 5, true);
+  buf.writeUInt32BE(type, 5);
 
-  buf.writeUInt32BE(dataLen, 9, true);
+  buf.writeUInt32BE(dataLen, 9);
   if (dataIsBuffer)
     data.copy(buf, 13);
   else
@@ -966,13 +966,13 @@ SSH2Stream.prototype.channelOpenConfirm = function(remoteChan, localChan,
 
   buf[0] = MESSAGE.CHANNEL_OPEN_CONFIRMATION;
 
-  buf.writeUInt32BE(remoteChan, 1, true);
+  buf.writeUInt32BE(remoteChan, 1);
 
-  buf.writeUInt32BE(localChan, 5, true);
+  buf.writeUInt32BE(localChan, 5);
 
-  buf.writeUInt32BE(initWindow, 9, true);
+  buf.writeUInt32BE(initWindow, 9);
 
-  buf.writeUInt32BE(maxPacket, 13, true);
+  buf.writeUInt32BE(maxPacket, 13);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN_CONFIRMATION (r:'
              + remoteChan
@@ -995,18 +995,18 @@ SSH2Stream.prototype.channelOpenFail = function(remoteChan, reason, desc,
 
   buf[0] = MESSAGE.CHANNEL_OPEN_FAILURE;
 
-  buf.writeUInt32BE(remoteChan, 1, true);
+  buf.writeUInt32BE(remoteChan, 1);
 
-  buf.writeUInt32BE(reason, 5, true);
+  buf.writeUInt32BE(reason, 5);
 
-  buf.writeUInt32BE(descLen, p, true);
+  buf.writeUInt32BE(descLen, p);
   p += 4;
   if (descLen) {
     buf.write(desc, p, descLen, 'utf8');
     p += descLen;
   }
 
-  buf.writeUInt32BE(langLen, p, true);
+  buf.writeUInt32BE(langLen, p);
   if (langLen)
     buf.write(lang, p += 4, langLen, 'ascii');
 
@@ -1027,7 +1027,7 @@ SSH2Stream.prototype.service = function(svcName) {
 
   buf[0] = MESSAGE.SERVICE_REQUEST;
 
-  buf.writeUInt32BE(svcNameLen, 1, true);
+  buf.writeUInt32BE(svcNameLen, 1);
   buf.write(svcName, 5, svcNameLen, 'ascii');
 
   this.debug('DEBUG: Outgoing: Writing SERVICE_REQUEST (' + svcName + ')');
@@ -1043,15 +1043,15 @@ SSH2Stream.prototype.tcpipForward = function(bindAddr, bindPort, wantReply) {
 
   buf[0] = MESSAGE.GLOBAL_REQUEST;
 
-  buf.writeUInt32BE(13, 1, true);
+  buf.writeUInt32BE(13, 1);
   buf.write('tcpip-forward', 5, 13, 'ascii');
 
   buf[18] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(addrlen, 19, true);
+  buf.writeUInt32BE(addrlen, 19);
   buf.write(bindAddr, 23, addrlen, 'ascii');
 
-  buf.writeUInt32BE(bindPort, 23 + addrlen, true);
+  buf.writeUInt32BE(bindPort, 23 + addrlen);
 
   this.debug('DEBUG: Outgoing: Writing GLOBAL_REQUEST (tcpip-forward)');
   return send(this, buf);
@@ -1066,15 +1066,15 @@ SSH2Stream.prototype.cancelTcpipForward = function(bindAddr, bindPort,
 
   buf[0] = MESSAGE.GLOBAL_REQUEST;
 
-  buf.writeUInt32BE(20, 1, true);
+  buf.writeUInt32BE(20, 1);
   buf.write('cancel-tcpip-forward', 5, 20, 'ascii');
 
   buf[25] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(addrlen, 26, true);
+  buf.writeUInt32BE(addrlen, 26);
   buf.write(bindAddr, 30, addrlen, 'ascii');
 
-  buf.writeUInt32BE(bindPort, 30 + addrlen, true);
+  buf.writeUInt32BE(bindPort, 30 + addrlen);
 
   this.debug('DEBUG: Outgoing: Writing GLOBAL_REQUEST (cancel-tcpip-forward)');
   return send(this, buf);
@@ -1089,12 +1089,12 @@ SSH2Stream.prototype.openssh_streamLocalForward = function(socketPath,
 
   buf[0] = MESSAGE.GLOBAL_REQUEST;
 
-  buf.writeUInt32BE(31, 1, true);
+  buf.writeUInt32BE(31, 1);
   buf.write('streamlocal-forward@openssh.com', 5, 31, 'ascii');
 
   buf[36] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(pathlen, 37, true);
+  buf.writeUInt32BE(pathlen, 37);
   buf.write(socketPath, 41, pathlen, 'utf8');
 
   this.debug('DEBUG: Outgoing: Writing GLOBAL_REQUEST (streamlocal-forward@openssh.com)');
@@ -1110,12 +1110,12 @@ SSH2Stream.prototype.openssh_cancelStreamLocalForward = function(socketPath,
 
   buf[0] = MESSAGE.GLOBAL_REQUEST;
 
-  buf.writeUInt32BE(38, 1, true);
+  buf.writeUInt32BE(38, 1);
   buf.write('cancel-streamlocal-forward@openssh.com', 5, 38, 'ascii');
 
   buf[43] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(pathlen, 44, true);
+  buf.writeUInt32BE(pathlen, 44);
   buf.write(socketPath, 48, pathlen, 'utf8');
 
   this.debug('DEBUG: Outgoing: Writing GLOBAL_REQUEST (cancel-streamlocal-forward@openssh.com)');
@@ -1133,24 +1133,24 @@ SSH2Stream.prototype.directTcpip = function(chan, initWindow, maxPacket, cfg) {
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(12, 1, true);
+  buf.writeUInt32BE(12, 1);
   buf.write('direct-tcpip', 5, 12, 'ascii');
 
-  buf.writeUInt32BE(chan, 17, true);
+  buf.writeUInt32BE(chan, 17);
 
-  buf.writeUInt32BE(initWindow, 21, true);
+  buf.writeUInt32BE(initWindow, 21);
 
-  buf.writeUInt32BE(maxPacket, 25, true);
+  buf.writeUInt32BE(maxPacket, 25);
 
-  buf.writeUInt32BE(dstlen, p, true);
+  buf.writeUInt32BE(dstlen, p);
   buf.write(cfg.dstIP, p += 4, dstlen, 'ascii');
 
-  buf.writeUInt32BE(cfg.dstPort, p += dstlen, true);
+  buf.writeUInt32BE(cfg.dstPort, p += dstlen);
 
-  buf.writeUInt32BE(srclen, p += 4, true);
+  buf.writeUInt32BE(srclen, p += 4);
   buf.write(cfg.srcIP, p += 4, srclen, 'ascii');
 
-  buf.writeUInt32BE(cfg.srcPort, p += srclen, true);
+  buf.writeUInt32BE(cfg.srcPort, p += srclen);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
              + chan
@@ -1168,16 +1168,16 @@ SSH2Stream.prototype.openssh_directStreamLocal = function(chan, initWindow,
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(30, 1, true);
+  buf.writeUInt32BE(30, 1);
   buf.write('direct-streamlocal@openssh.com', 5, 30, 'ascii');
 
-  buf.writeUInt32BE(chan, 35, true);
+  buf.writeUInt32BE(chan, 35);
 
-  buf.writeUInt32BE(initWindow, 39, true);
+  buf.writeUInt32BE(initWindow, 39);
 
-  buf.writeUInt32BE(maxPacket, 43, true);
+  buf.writeUInt32BE(maxPacket, 43);
 
-  buf.writeUInt32BE(pathlen, p, true);
+  buf.writeUInt32BE(pathlen, p);
   buf.write(cfg.socketPath, p += 4, pathlen, 'utf8');
 
   // reserved fields (string and uint32)
@@ -1196,7 +1196,7 @@ SSH2Stream.prototype.openssh_noMoreSessions = function(wantReply) {
 
   buf[0] = MESSAGE.GLOBAL_REQUEST;
 
-  buf.writeUInt32BE(28, 1, true);
+  buf.writeUInt32BE(28, 1);
   buf.write('no-more-sessions@openssh.com', 5, 28, 'ascii');
 
   buf[33] = (wantReply === undefined || wantReply === true ? 1 : 0);
@@ -1213,14 +1213,14 @@ SSH2Stream.prototype.session = function(chan, initWindow, maxPacket) {
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(7, 1, true);
+  buf.writeUInt32BE(7, 1);
   buf.write('session', 5, 7, 'ascii');
 
-  buf.writeUInt32BE(chan, 12, true);
+  buf.writeUInt32BE(chan, 12);
 
-  buf.writeUInt32BE(initWindow, 16, true);
+  buf.writeUInt32BE(initWindow, 16);
 
-  buf.writeUInt32BE(maxPacket, 20, true);
+  buf.writeUInt32BE(maxPacket, 20);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
              + chan
@@ -1236,20 +1236,20 @@ SSH2Stream.prototype.windowChange = function(chan, rows, cols, height, width) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(13, 5, true);
+  buf.writeUInt32BE(13, 5);
   buf.write('window-change', 9, 13, 'ascii');
 
   buf[22] = 0;
 
-  buf.writeUInt32BE(cols, 23, true);
+  buf.writeUInt32BE(cols, 23);
 
-  buf.writeUInt32BE(rows, 27, true);
+  buf.writeUInt32BE(rows, 27);
 
-  buf.writeUInt32BE(width, 31, true);
+  buf.writeUInt32BE(width, 31);
 
-  buf.writeUInt32BE(height, 35, true);
+  buf.writeUInt32BE(height, 35);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
              + chan
@@ -1280,25 +1280,25 @@ SSH2Stream.prototype.pty = function(chan, rows, cols, height,
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(7, 5, true);
+  buf.writeUInt32BE(7, 5);
   buf.write('pty-req', 9, 7, 'ascii');
 
   buf[16] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(termLen, 17, true);
+  buf.writeUInt32BE(termLen, 17);
   buf.write(term, 21, termLen, 'utf8');
 
-  buf.writeUInt32BE(cols, p += termLen, true);
+  buf.writeUInt32BE(cols, p += termLen);
 
-  buf.writeUInt32BE(rows, p += 4, true);
+  buf.writeUInt32BE(rows, p += 4);
 
-  buf.writeUInt32BE(width, p += 4, true);
+  buf.writeUInt32BE(width, p += 4);
 
-  buf.writeUInt32BE(height, p += 4, true);
+  buf.writeUInt32BE(height, p += 4);
 
-  buf.writeUInt32BE(modesLen, p += 4, true);
+  buf.writeUInt32BE(modesLen, p += 4);
   p += 4;
   if (Array.isArray(modes)) {
     for (var i = 0; i < modesLen; ++i)
@@ -1321,9 +1321,9 @@ SSH2Stream.prototype.shell = function(chan, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(5, 5, true);
+  buf.writeUInt32BE(5, 5);
   buf.write('shell', 9, 5, 'ascii');
 
   buf[14] = (wantReply === undefined || wantReply === true ? 1 : 0);
@@ -1343,14 +1343,14 @@ SSH2Stream.prototype.exec = function(chan, cmd, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(4, 5, true);
+  buf.writeUInt32BE(4, 5);
   buf.write('exec', 9, 4, 'ascii');
 
   buf[13] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(cmdlen, 14, true);
+  buf.writeUInt32BE(cmdlen, 14);
   if (Buffer.isBuffer(cmd))
     cmd.copy(buf, 18);
   else
@@ -1378,14 +1378,14 @@ SSH2Stream.prototype.signal = function(chan, signal) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(6, 5, true);
+  buf.writeUInt32BE(6, 5);
   buf.write('signal', 9, 6, 'ascii');
 
   buf[15] = 0;
 
-  buf.writeUInt32BE(signalLen, 16, true);
+  buf.writeUInt32BE(signalLen, 16);
   buf.write(signal, 20, signalLen, 'ascii');
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
@@ -1404,17 +1404,17 @@ SSH2Stream.prototype.env = function(chan, key, val, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(3, 5, true);
+  buf.writeUInt32BE(3, 5);
   buf.write('env', 9, 3, 'ascii');
 
   buf[12] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(keyLen, 13, true);
+  buf.writeUInt32BE(keyLen, 13);
   buf.write(key, 17, keyLen, 'ascii');
 
-  buf.writeUInt32BE(valLen, 17 + keyLen, true);
+  buf.writeUInt32BE(valLen, 17 + keyLen);
   if (Buffer.isBuffer(val))
     val.copy(buf, 17 + keyLen + 4);
   else
@@ -1437,16 +1437,16 @@ SSH2Stream.prototype.x11Forward = function(chan, cfg, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(7, 5, true);
+  buf.writeUInt32BE(7, 5);
   buf.write('x11-req', 9, 7, 'ascii');
 
   buf[16] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
   buf[17] = (cfg.single ? 1 : 0);
 
-  buf.writeUInt32BE(protolen, 18, true);
+  buf.writeUInt32BE(protolen, 18);
   var bp = 22;
   if (Buffer.isBuffer(cfg.protocol))
     cfg.protocol.copy(buf, bp);
@@ -1454,7 +1454,7 @@ SSH2Stream.prototype.x11Forward = function(chan, cfg, wantReply) {
     buf.write(cfg.protocol, bp, protolen, 'utf8');
   bp += protolen;
 
-  buf.writeUInt32BE(cookielen, bp, true);
+  buf.writeUInt32BE(cookielen, bp);
   bp += 4;
   if (Buffer.isBuffer(cfg.cookie))
     cfg.cookie.copy(buf, bp);
@@ -1462,7 +1462,7 @@ SSH2Stream.prototype.x11Forward = function(chan, cfg, wantReply) {
     buf.write(cfg.cookie, bp, cookielen, 'utf8');
   bp += cookielen;
 
-  buf.writeUInt32BE((cfg.screen || 0), bp, true);
+  buf.writeUInt32BE((cfg.screen || 0), bp);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
              + chan
@@ -1479,14 +1479,14 @@ SSH2Stream.prototype.subsystem = function(chan, name, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(9, 5, true);
+  buf.writeUInt32BE(9, 5);
   buf.write('subsystem', 9, 9, 'ascii');
 
   buf[18] = (wantReply === undefined || wantReply === true ? 1 : 0);
 
-  buf.writeUInt32BE(nameLen, 19, true);
+  buf.writeUInt32BE(nameLen, 19);
   buf.write(name, 23, nameLen, 'ascii');
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
@@ -1505,9 +1505,9 @@ SSH2Stream.prototype.openssh_agentForward = function(chan, wantReply) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(26, 5, true);
+  buf.writeUInt32BE(26, 5);
   buf.write('auth-agent-req@openssh.com', 9, 26, 'ascii');
 
   buf[35] = (wantReply === undefined || wantReply === true ? 1 : 0);
@@ -1534,18 +1534,18 @@ SSH2Stream.prototype.authPassword = function(username, password) {
 
   buf[p] = MESSAGE.USERAUTH_REQUEST;
 
-  buf.writeUInt32BE(userLen, ++p, true);
+  buf.writeUInt32BE(userLen, ++p);
   buf.write(username, p += 4, userLen, 'utf8');
 
-  buf.writeUInt32BE(14, p += userLen, true);
+  buf.writeUInt32BE(14, p += userLen);
   buf.write('ssh-connection', p += 4, 14, 'ascii');
 
-  buf.writeUInt32BE(8, p += 14, true);
+  buf.writeUInt32BE(8, p += 14);
   buf.write('password', p += 4, 8, 'ascii');
 
   buf[p += 8] = 0;
 
-  buf.writeUInt32BE(passLen, ++p, true);
+  buf.writeUInt32BE(passLen, ++p);
   buf.write(password, p += 4, passLen, 'utf8');
 
   this._state.authsQueue.push('password');
@@ -1566,7 +1566,7 @@ SSH2Stream.prototype.authPK = function(username, pubKey, cbSign) {
   } else {
     pubKeyFullType = pubKey.toString('ascii',
                                      4,
-                                     4 + pubKey.readUInt32BE(0, true));
+                                     4 + pubKey.readUInt32BE(0));
   }
 
   var userLen = Buffer.byteLength(username);
@@ -1585,27 +1585,27 @@ SSH2Stream.prototype.authPK = function(username, pubKey, cbSign) {
                       );
 
   if (cbSign) {
-    buf.writeUInt32BE(sesLen, p, true);
+    buf.writeUInt32BE(sesLen, p);
     outstate.sessionId.copy(buf, p += 4);
     buf[p += sesLen] = MESSAGE.USERAUTH_REQUEST;
   } else
     buf[p] = MESSAGE.USERAUTH_REQUEST;
 
-  buf.writeUInt32BE(userLen, ++p, true);
+  buf.writeUInt32BE(userLen, ++p);
   buf.write(username, p += 4, userLen, 'utf8');
 
-  buf.writeUInt32BE(14, p += userLen, true);
+  buf.writeUInt32BE(14, p += userLen);
   buf.write('ssh-connection', p += 4, 14, 'ascii');
 
-  buf.writeUInt32BE(9, p += 14, true);
+  buf.writeUInt32BE(9, p += 14);
   buf.write('publickey', p += 4, 9, 'ascii');
 
   buf[p += 9] = (cbSign ? 1 : 0);
 
-  buf.writeUInt32BE(algoLen, ++p, true);
+  buf.writeUInt32BE(algoLen, ++p);
   buf.write(pubKeyFullType, p += 4, algoLen, 'ascii');
 
-  buf.writeUInt32BE(pubKeyLen, p += algoLen, true);
+  buf.writeUInt32BE(pubKeyLen, p += algoLen);
   pubKey.copy(buf, p += 4);
 
   if (!cbSign) {
@@ -1638,26 +1638,26 @@ SSH2Stream.prototype.authPK = function(username, pubKey, cbSign) {
 
     sigbuf[p] = MESSAGE.USERAUTH_REQUEST;
 
-    sigbuf.writeUInt32BE(userLen, ++p, true);
+    sigbuf.writeUInt32BE(userLen, ++p);
     sigbuf.write(username, p += 4, userLen, 'utf8');
 
-    sigbuf.writeUInt32BE(14, p += userLen, true);
+    sigbuf.writeUInt32BE(14, p += userLen);
     sigbuf.write('ssh-connection', p += 4, 14, 'ascii');
 
-    sigbuf.writeUInt32BE(9, p += 14, true);
+    sigbuf.writeUInt32BE(9, p += 14);
     sigbuf.write('publickey', p += 4, 9, 'ascii');
 
     sigbuf[p += 9] = 1;
 
-    sigbuf.writeUInt32BE(algoLen, ++p, true);
+    sigbuf.writeUInt32BE(algoLen, ++p);
     sigbuf.write(pubKeyFullType, p += 4, algoLen, 'ascii');
 
-    sigbuf.writeUInt32BE(pubKeyLen, p += algoLen, true);
+    sigbuf.writeUInt32BE(pubKeyLen, p += algoLen);
     pubKey.copy(sigbuf, p += 4);
-    sigbuf.writeUInt32BE(4 + algoLen + 4 + sigLen, p += pubKeyLen, true);
-    sigbuf.writeUInt32BE(algoLen, p += 4, true);
+    sigbuf.writeUInt32BE(4 + algoLen + 4 + sigLen, p += pubKeyLen);
+    sigbuf.writeUInt32BE(algoLen, p += 4);
     sigbuf.write(pubKeyFullType, p += 4, algoLen, 'ascii');
-    sigbuf.writeUInt32BE(sigLen, p += algoLen, true);
+    sigbuf.writeUInt32BE(sigLen, p += algoLen);
     signature.copy(sigbuf, p += 4);
 
     // Servers shouldn't send packet type 60 in response to signed publickey
@@ -1685,7 +1685,7 @@ SSH2Stream.prototype.authHostbased = function(username, pubKey, hostname,
   } else {
     pubKeyFullType = pubKey.toString('ascii',
                                      4,
-                                     4 + pubKey.readUInt32BE(0, true));
+                                     4 + pubKey.readUInt32BE(0));
   }
 
   var userLen = Buffer.byteLength(username);
@@ -1706,30 +1706,30 @@ SSH2Stream.prototype.authHostbased = function(username, pubKey, hostname,
                        + 4 + userlocalLen
                       );
 
-  buf.writeUInt32BE(sesLen, p, true);
+  buf.writeUInt32BE(sesLen, p);
   outstate.sessionId.copy(buf, p += 4);
 
   buf[p += sesLen] = MESSAGE.USERAUTH_REQUEST;
 
-  buf.writeUInt32BE(userLen, ++p, true);
+  buf.writeUInt32BE(userLen, ++p);
   buf.write(username, p += 4, userLen, 'utf8');
 
-  buf.writeUInt32BE(14, p += userLen, true);
+  buf.writeUInt32BE(14, p += userLen);
   buf.write('ssh-connection', p += 4, 14, 'ascii');
 
-  buf.writeUInt32BE(9, p += 14, true);
+  buf.writeUInt32BE(9, p += 14);
   buf.write('hostbased', p += 4, 9, 'ascii');
 
-  buf.writeUInt32BE(algoLen, p += 9, true);
+  buf.writeUInt32BE(algoLen, p += 9);
   buf.write(pubKeyFullType, p += 4, algoLen, 'ascii');
 
-  buf.writeUInt32BE(pubKeyLen, p += algoLen, true);
+  buf.writeUInt32BE(pubKeyLen, p += algoLen);
   pubKey.copy(buf, p += 4);
 
-  buf.writeUInt32BE(hostnameLen, p += pubKeyLen, true);
+  buf.writeUInt32BE(hostnameLen, p += pubKeyLen);
   buf.write(hostname, p += 4, hostnameLen, 'ascii');
 
-  buf.writeUInt32BE(userlocalLen, p += hostnameLen, true);
+  buf.writeUInt32BE(userlocalLen, p += hostnameLen);
   buf.write(userlocal, p += 4, userlocalLen, 'utf8');
 
   cbSign(buf, function(signature) {
@@ -1743,7 +1743,7 @@ SSH2Stream.prototype.authHostbased = function(username, pubKey, hostname,
     var sigbuf = new Buffer((buf.length - sesLen) + sigLen);
 
     buf.copy(sigbuf, 0, 4 + sesLen);
-    sigbuf.writeUInt32BE(sigLen, sigbuf.length - sigLen - 4, true);
+    sigbuf.writeUInt32BE(sigLen, sigbuf.length - sigLen - 4);
     signature.copy(sigbuf, sigbuf.length - sigLen);
 
     self._state.authsQueue.push('hostbased');
@@ -1768,18 +1768,18 @@ SSH2Stream.prototype.authKeyboard = function(username) {
 
   buf[p] = MESSAGE.USERAUTH_REQUEST;
 
-  buf.writeUInt32BE(userLen, ++p, true);
+  buf.writeUInt32BE(userLen, ++p);
   buf.write(username, p += 4, userLen, 'utf8');
 
-  buf.writeUInt32BE(14, p += userLen, true);
+  buf.writeUInt32BE(14, p += userLen);
   buf.write('ssh-connection', p += 4, 14, 'ascii');
 
-  buf.writeUInt32BE(20, p += 14, true);
+  buf.writeUInt32BE(20, p += 14);
   buf.write('keyboard-interactive', p += 4, 20, 'ascii');
 
-  buf.writeUInt32BE(0, p += 20, true);
+  buf.writeUInt32BE(0, p += 20);
 
-  buf.writeUInt32BE(0, p += 4, true);
+  buf.writeUInt32BE(0, p += 4);
 
   this._state.authsQueue.push('keyboard-interactive');
   this.debug('DEBUG: Outgoing: Writing USERAUTH_REQUEST (keyboard-interactive)');
@@ -1799,13 +1799,13 @@ SSH2Stream.prototype.authNone = function(username) {
 
   buf[p] = MESSAGE.USERAUTH_REQUEST;
 
-  buf.writeUInt32BE(userLen, ++p, true);
+  buf.writeUInt32BE(userLen, ++p);
   buf.write(username, p += 4, userLen, 'utf8');
 
-  buf.writeUInt32BE(14, p += userLen, true);
+  buf.writeUInt32BE(14, p += userLen);
   buf.write('ssh-connection', p += 4, 14, 'ascii');
 
-  buf.writeUInt32BE(4, p += 14, true);
+  buf.writeUInt32BE(4, p += 14);
   buf.write('none', p += 4, 4, 'ascii');
 
   this._state.authsQueue.push('none');
@@ -1830,12 +1830,12 @@ SSH2Stream.prototype.authInfoRes = function(responses) {
 
   buf[p++] = MESSAGE.USERAUTH_INFO_RESPONSE;
 
-  buf.writeUInt32BE(responses ? responses.length : 0, p, true);
+  buf.writeUInt32BE(responses ? responses.length : 0, p);
   if (responses) {
     p += 4;
     for (i = 0, len = responses.length; i < len; ++i) {
       resLen = Buffer.byteLength(responses[i]);
-      buf.writeUInt32BE(resLen, p, true);
+      buf.writeUInt32BE(resLen, p);
       p += 4;
       if (resLen) {
         buf.write(responses[i], p, resLen, 'utf8');
@@ -1859,7 +1859,7 @@ SSH2Stream.prototype.serviceAccept = function(svcName) {
 
   buf[0] = MESSAGE.SERVICE_ACCEPT;
 
-  buf.writeUInt32BE(svcNameLen, 1, true);
+  buf.writeUInt32BE(svcNameLen, 1);
   buf.write(svcName, 5, svcNameLen, 'ascii');
 
   this.debug('DEBUG: Outgoing: Writing SERVICE_ACCEPT (' + svcName + ')');
@@ -1879,7 +1879,7 @@ SSH2Stream.prototype.serviceAccept = function(svcName) {
     }
     var packet = new Buffer(packetLen);
     packet[0] = MESSAGE.USERAUTH_BANNER;
-    packet.writeUInt32BE(bannerLen, 1, true);
+    packet.writeUInt32BE(bannerLen, 1);
     packet.write(this.banner, 5, bannerLen, 'utf8');
     packet.fill(0, packetLen - 4); // Empty language tag
     this.debug('DEBUG: Outgoing: Writing USERAUTH_BANNER');
@@ -1901,24 +1901,24 @@ SSH2Stream.prototype.forwardedTcpip = function(chan, initWindow, maxPacket,
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(15, 1, true);
+  buf.writeUInt32BE(15, 1);
   buf.write('forwarded-tcpip', 5, 15, 'ascii');
 
-  buf.writeUInt32BE(chan, 20, true);
+  buf.writeUInt32BE(chan, 20);
 
-  buf.writeUInt32BE(initWindow, 24, true);
+  buf.writeUInt32BE(initWindow, 24);
 
-  buf.writeUInt32BE(maxPacket, 28, true);
+  buf.writeUInt32BE(maxPacket, 28);
 
-  buf.writeUInt32BE(boundAddrLen, 32, true);
+  buf.writeUInt32BE(boundAddrLen, 32);
   buf.write(cfg.boundAddr, 36, boundAddrLen, 'ascii');
 
-  buf.writeUInt32BE(cfg.boundPort, p, true);
+  buf.writeUInt32BE(cfg.boundPort, p);
 
-  buf.writeUInt32BE(remoteAddrLen, p += 4, true);
+  buf.writeUInt32BE(remoteAddrLen, p += 4);
   buf.write(cfg.remoteAddr, p += 4, remoteAddrLen, 'ascii');
 
-  buf.writeUInt32BE(cfg.remotePort, p += remoteAddrLen, true);
+  buf.writeUInt32BE(cfg.remotePort, p += remoteAddrLen);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
              + chan
@@ -1935,19 +1935,19 @@ SSH2Stream.prototype.x11 = function(chan, initWindow, maxPacket, cfg) {
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(3, 1, true);
+  buf.writeUInt32BE(3, 1);
   buf.write('x11', 5, 3, 'ascii');
 
-  buf.writeUInt32BE(chan, 8, true);
+  buf.writeUInt32BE(chan, 8);
 
-  buf.writeUInt32BE(initWindow, 12, true);
+  buf.writeUInt32BE(initWindow, 12);
 
-  buf.writeUInt32BE(maxPacket, 16, true);
+  buf.writeUInt32BE(maxPacket, 16);
 
-  buf.writeUInt32BE(addrLen, 20, true);
+  buf.writeUInt32BE(addrLen, 20);
   buf.write(cfg.originAddr, 24, addrLen, 'ascii');
 
-  buf.writeUInt32BE(cfg.originPort, p, true);
+  buf.writeUInt32BE(cfg.originPort, p);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
              + chan
@@ -1964,19 +1964,19 @@ SSH2Stream.prototype.openssh_forwardedStreamLocal = function(chan, initWindow,
 
   buf[0] = MESSAGE.CHANNEL_OPEN;
 
-  buf.writeUInt32BE(33, 1, true);
+  buf.writeUInt32BE(33, 1);
   buf.write('forwarded-streamlocal@openssh.com', 5, 33, 'ascii');
 
-  buf.writeUInt32BE(chan, 38, true);
+  buf.writeUInt32BE(chan, 38);
 
-  buf.writeUInt32BE(initWindow, 42, true);
+  buf.writeUInt32BE(initWindow, 42);
 
-  buf.writeUInt32BE(maxPacket, 46, true);
+  buf.writeUInt32BE(maxPacket, 46);
 
-  buf.writeUInt32BE(pathlen, 50, true);
+  buf.writeUInt32BE(pathlen, 50);
   buf.write(cfg.socketPath, 54, pathlen, 'utf8');
 
-  buf.writeUInt32BE(0, 54 + pathlen, true);
+  buf.writeUInt32BE(0, 54 + pathlen);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
              + chan
@@ -1992,14 +1992,14 @@ SSH2Stream.prototype.exitStatus = function(chan, status) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(11, 5, true);
+  buf.writeUInt32BE(11, 5);
   buf.write('exit-status', 9, 11, 'ascii');
 
   buf[20] = 0;
 
-  buf.writeUInt32BE(status, 21, true);
+  buf.writeUInt32BE(status, 21);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
              + chan
@@ -2018,26 +2018,26 @@ SSH2Stream.prototype.exitSignal = function(chan, name, coreDumped, msg) {
 
   buf[0] = MESSAGE.CHANNEL_REQUEST;
 
-  buf.writeUInt32BE(chan, 1, true);
+  buf.writeUInt32BE(chan, 1);
 
-  buf.writeUInt32BE(11, 5, true);
+  buf.writeUInt32BE(11, 5);
   buf.write('exit-signal', 9, 11, 'ascii');
 
   buf[20] = 0;
 
-  buf.writeUInt32BE(nameLen, 21, true);
+  buf.writeUInt32BE(nameLen, 21);
   buf.write(name, 25, nameLen, 'utf8');
 
   buf[p++] = (coreDumped ? 1 : 0);
 
-  buf.writeUInt32BE(msgLen, p, true);
+  buf.writeUInt32BE(msgLen, p);
   p += 4;
   if (msgLen) {
     buf.write(msg, p, msgLen, 'utf8');
     p += msgLen;
   }
 
-  buf.writeUInt32BE(0, p, true);
+  buf.writeUInt32BE(0, p);
 
   this.debug('DEBUG: Outgoing: Writing CHANNEL_REQUEST ('
              + chan
@@ -2076,7 +2076,7 @@ SSH2Stream.prototype.authFailure = function(authMethods, isPartial) {
 
   buf[0] = MESSAGE.USERAUTH_FAILURE;
 
-  buf.writeUInt32BE(methodsLen, 1, true);
+  buf.writeUInt32BE(methodsLen, 1);
   buf.write(methods, 5, methodsLen, 'ascii');
 
   buf[5 + methodsLen] = (isPartial === true ? 1 : 0);
@@ -2111,10 +2111,10 @@ SSH2Stream.prototype.authPKOK = function(keyAlgo, key) {
 
   buf[0] = MESSAGE.USERAUTH_PK_OK;
 
-  buf.writeUInt32BE(keyAlgoLen, 1, true);
+  buf.writeUInt32BE(keyAlgoLen, 1);
   buf.write(keyAlgo, 5, keyAlgoLen, 'ascii');
 
-  buf.writeUInt32BE(keyLen, 5 + keyAlgoLen, true);
+  buf.writeUInt32BE(keyLen, 5 + keyAlgoLen);
   key.copy(buf, 5 + keyAlgoLen + 4);
 
   this._state.authsQueue.shift();
@@ -2132,10 +2132,10 @@ SSH2Stream.prototype.authPasswdChg = function(prompt, lang) {
 
   buf[p] = MESSAGE.USERAUTH_PASSWD_CHANGEREQ;
 
-  buf.writeUInt32BE(promptLen, ++p, true);
+  buf.writeUInt32BE(promptLen, ++p);
   buf.write(prompt, p += 4, promptLen, 'utf8');
 
-  buf.writeUInt32BE(langLen, p += promptLen, true);
+  buf.writeUInt32BE(langLen, p += promptLen);
   if (langLen)
     buf.write(lang, p += 4, langLen, 'ascii');
 
@@ -2161,29 +2161,29 @@ SSH2Stream.prototype.authInfoReq = function(name, instructions, prompts) {
 
   buf[p++] = MESSAGE.USERAUTH_INFO_REQUEST;
 
-  buf.writeUInt32BE(nameLen, p, true);
+  buf.writeUInt32BE(nameLen, p);
   p += 4;
   if (name) {
     buf.write(name, p, nameLen, 'utf8');
     p += nameLen;
   }
 
-  buf.writeUInt32BE(instrLen, p, true);
+  buf.writeUInt32BE(instrLen, p);
   p += 4;
   if (instructions) {
     buf.write(instructions, p, instrLen, 'utf8');
     p += instrLen;
   }
 
-  buf.writeUInt32BE(0, p, true);
+  buf.writeUInt32BE(0, p);
   p += 4;
 
-  buf.writeUInt32BE(prompts.length, p, true);
+  buf.writeUInt32BE(prompts.length, p);
   p += 4;
   for (i = 0, len = prompts.length; i < len; ++i) {
     prompt = prompts[i];
     promptLen = Buffer.byteLength(prompt.prompt);
-    buf.writeUInt32BE(promptLen, p, true);
+    buf.writeUInt32BE(promptLen, p);
     p += 4;
     if (promptLen) {
       buf.write(prompt.prompt, p, promptLen, 'utf8');
@@ -2774,29 +2774,29 @@ function onKEXDH_REPLY(self, info, verifiedHost) { // Client
   var bp = 0;
   var exchangeBuf = new Buffer(exchangeBufLen);
 
-  exchangeBuf.writeUInt32BE(len_ident, bp, true);
+  exchangeBuf.writeUInt32BE(len_ident, bp);
   bp += 4;
   exchangeBuf.write(self.config.ident, bp, 'utf8'); // V_C
   bp += len_ident;
 
-  exchangeBuf.writeUInt32BE(len_sident, bp, true);
+  exchangeBuf.writeUInt32BE(len_sident, bp);
   bp += 4;
   exchangeBuf.write(instate.identRaw, bp, 'utf8'); // V_S
   bp += len_sident;
 
-  exchangeBuf.writeUInt32BE(len_init, bp, true);
+  exchangeBuf.writeUInt32BE(len_init, bp);
   bp += 4;
   outstate.kexinit.copy(exchangeBuf, bp); // I_C
   bp += len_init;
   outstate.kexinit = undefined;
 
-  exchangeBuf.writeUInt32BE(len_sinit, bp, true);
+  exchangeBuf.writeUInt32BE(len_sinit, bp);
   bp += 4;
   instate.kexinit.copy(exchangeBuf, bp); // I_S
   bp += len_sinit;
   instate.kexinit = undefined;
 
-  exchangeBuf.writeUInt32BE(len_hostkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_hostkey, bp);
   bp += 4;
   info.hostkey.copy(exchangeBuf, bp); // K_S
   bp += len_hostkey;
@@ -2805,14 +2805,14 @@ function onKEXDH_REPLY(self, info, verifiedHost) { // Client
     KEXDH_GEX_REQ_PACKET.slice(1).copy(exchangeBuf, bp); // min, n, max
     bp += (4 * 3); // Skip over bytes just copied
 
-    exchangeBuf.writeUInt32BE(len_gex_prime, bp, true);
+    exchangeBuf.writeUInt32BE(len_gex_prime, bp);
     bp += 4;
     if (gex_prime[idx_gex_prime] & 0x80)
       exchangeBuf[bp++] = 0;
     gex_prime.copy(exchangeBuf, bp, idx_gex_prime); // p
     bp += len_gex_prime - (gex_prime[idx_gex_prime] & 0x80 ? 1 : 0);
 
-    exchangeBuf.writeUInt32BE(len_gex_gen, bp, true);
+    exchangeBuf.writeUInt32BE(len_gex_gen, bp);
     bp += 4;
     if (gex_gen[idx_gex_gen] & 0x80)
       exchangeBuf[bp++] = 0;
@@ -2820,21 +2820,21 @@ function onKEXDH_REPLY(self, info, verifiedHost) { // Client
     bp += len_gex_gen - (gex_gen[idx_gex_gen] & 0x80 ? 1 : 0);
   }
 
-  exchangeBuf.writeUInt32BE(len_pubkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_pubkey, bp);
   bp += 4;
   if (outstate.pubkey[idx_pubkey] & 0x80)
     exchangeBuf[bp++] = 0;
   outstate.pubkey.copy(exchangeBuf, bp, idx_pubkey); // e
   bp += len_pubkey - (outstate.pubkey[idx_pubkey] & 0x80 ? 1 : 0);
 
-  exchangeBuf.writeUInt32BE(len_spubkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_spubkey, bp);
   bp += 4;
   if (info.pubkey[idx_spubkey] & 0x80)
     exchangeBuf[bp++] = 0;
   info.pubkey.copy(exchangeBuf, bp, idx_spubkey); // f
   bp += len_spubkey - (info.pubkey[idx_spubkey] & 0x80 ? 1 : 0);
 
-  exchangeBuf.writeUInt32BE(len_secret, bp, true);
+  exchangeBuf.writeUInt32BE(len_secret, bp);
   bp += 4;
   if (info.secret[idx_secret] & 0x80)
     exchangeBuf[bp++] = 0;
@@ -2968,7 +2968,7 @@ function onNEWKEYS(self) { // Client/Server
   // interpret packet type 60.
   state.authsQueue = [];
 
-  secret.writeUInt32BE(len_secret, p, true);
+  secret.writeUInt32BE(len_secret, p);
   p += 4;
   if (outstate.kexsecret[idx_secret] & 0x80)
     secret[p++] = 0;
@@ -3865,7 +3865,7 @@ function parsePacket(self, callback) {
         }
 
         blob = new Buffer(4 + outstate.sessionId.length + blobEnd);
-        blob.writeUInt32BE(outstate.sessionId.length, 0, true);
+        blob.writeUInt32BE(outstate.sessionId.length, 0);
         outstate.sessionId.copy(blob, 4);
         payload.copy(blob, 4 + outstate.sessionId.length, 0, blobEnd);
       }
@@ -4021,7 +4021,7 @@ function parsePacket(self, callback) {
     // Unknown packet type
     var unimpl = new Buffer(1 + 4);
     unimpl[0] = MESSAGE.UNIMPLEMENTED;
-    unimpl.writeUInt32BE(seqno, 1, true);
+    unimpl.writeUInt32BE(seqno, 1);
     send(self, unimpl);
   }
 }
@@ -4744,8 +4744,8 @@ function hmacVerify(self, data) {
   } else {
     var calcHmac = crypto.createHmac(SSH_TO_OPENSSL[hmac.type], hmac.key);
 
-    hmac.bufCompute.writeUInt32BE(instate.seqno, 0, true);
-    hmac.bufCompute.writeUInt32BE(instate.pktLen, 4, true);
+    hmac.bufCompute.writeUInt32BE(instate.seqno, 0);
+    hmac.bufCompute.writeUInt32BE(instate.pktLen, 4);
     hmac.bufCompute[8] = instate.padLen;
 
     calcHmac.update(hmac.bufCompute);
@@ -4789,7 +4789,7 @@ function bytesToModes(buffer) {
         || TERMINAL_MODE[opcode] === undefined
         || i + 5 > len)
       break;
-    modes[TERMINAL_MODE[opcode]] = buffer.readUInt32BE(i + 1, true);
+    modes[TERMINAL_MODE[opcode]] = buffer.readUInt32BE(i + 1);
   }
 
   return modes;
@@ -4880,42 +4880,42 @@ function KEXINIT(self, cb) { // Client/Server
     if (myCookie !== false)
       myCookie.copy(buf, 1);
 
-    buf.writeUInt32BE(kexBuf.length, p, true);
+    buf.writeUInt32BE(kexBuf.length, p);
     p += 4;
     kexBuf.copy(buf, p);
     p += kexBuf.length;
 
-    buf.writeUInt32BE(hostKeyBuf.length, p, true);
+    buf.writeUInt32BE(hostKeyBuf.length, p);
     p += 4;
     hostKeyBuf.copy(buf, p);
     p += hostKeyBuf.length;
 
-    buf.writeUInt32BE(algos.cipherBuf.length, p, true);
+    buf.writeUInt32BE(algos.cipherBuf.length, p);
     p += 4;
     algos.cipherBuf.copy(buf, p);
     p += algos.cipherBuf.length;
 
-    buf.writeUInt32BE(algos.cipherBuf.length, p, true);
+    buf.writeUInt32BE(algos.cipherBuf.length, p);
     p += 4;
     algos.cipherBuf.copy(buf, p);
     p += algos.cipherBuf.length;
 
-    buf.writeUInt32BE(algos.hmacBuf.length, p, true);
+    buf.writeUInt32BE(algos.hmacBuf.length, p);
     p += 4;
     algos.hmacBuf.copy(buf, p);
     p += algos.hmacBuf.length;
 
-    buf.writeUInt32BE(algos.hmacBuf.length, p, true);
+    buf.writeUInt32BE(algos.hmacBuf.length, p);
     p += 4;
     algos.hmacBuf.copy(buf, p);
     p += algos.hmacBuf.length;
 
-    buf.writeUInt32BE(algos.compressBuf.length, p, true);
+    buf.writeUInt32BE(algos.compressBuf.length, p);
     p += 4;
     algos.compressBuf.copy(buf, p);
     p += algos.compressBuf.length;
 
-    buf.writeUInt32BE(algos.compressBuf.length, p, true);
+    buf.writeUInt32BE(algos.compressBuf.length, p);
     p += 4;
     algos.compressBuf.copy(buf, p);
     p += algos.compressBuf.length;
@@ -4958,7 +4958,7 @@ function KEXDH_INIT(self) { // Client
       self.debug('DEBUG: Outgoing: Writing KEXDH_INIT');
   }
 
-  buf.writeUInt32BE(outstate.pubkey.length, 1, true);
+  buf.writeUInt32BE(outstate.pubkey.length, 1);
   outstate.pubkey.copy(buf, 5);
 
   return send(self, buf, undefined, true);
@@ -5075,29 +5075,29 @@ function KEXDH_REPLY(self, e) { // Server
   var bp = 0;
   var exchangeBuf = new Buffer(exchangeBufLen);
 
-  exchangeBuf.writeUInt32BE(len_ident, bp, true);
+  exchangeBuf.writeUInt32BE(len_ident, bp);
   bp += 4;
   exchangeBuf.write(instate.identRaw, bp, 'utf8'); // V_C
   bp += len_ident;
 
-  exchangeBuf.writeUInt32BE(len_sident, bp, true);
+  exchangeBuf.writeUInt32BE(len_sident, bp);
   bp += 4;
   exchangeBuf.write(self.config.ident, bp, 'utf8'); // V_S
   bp += len_sident;
 
-  exchangeBuf.writeUInt32BE(len_init, bp, true);
+  exchangeBuf.writeUInt32BE(len_init, bp);
   bp += 4;
   instate.kexinit.copy(exchangeBuf, bp); // I_C
   bp += len_init;
   instate.kexinit = undefined;
 
-  exchangeBuf.writeUInt32BE(len_sinit, bp, true);
+  exchangeBuf.writeUInt32BE(len_sinit, bp);
   bp += 4;
   outstate.kexinit.copy(exchangeBuf, bp); // I_S
   bp += len_sinit;
   outstate.kexinit = undefined;
 
-  exchangeBuf.writeUInt32BE(len_hostkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_hostkey, bp);
   bp += 4;
   hostkey.copy(exchangeBuf, bp); // K_S
   bp += len_hostkey;
@@ -5106,14 +5106,14 @@ function KEXDH_REPLY(self, e) { // Server
     KEXDH_GEX_REQ_PACKET.slice(1).copy(exchangeBuf, bp); // min, n, max
     bp += (4 * 3); // Skip over bytes just copied
 
-    exchangeBuf.writeUInt32BE(len_gex_prime, bp, true);
+    exchangeBuf.writeUInt32BE(len_gex_prime, bp);
     bp += 4;
     if (gex_prime[idx_gex_prime] & 0x80)
       exchangeBuf[bp++] = 0;
     gex_prime.copy(exchangeBuf, bp, idx_gex_prime); // p
     bp += len_gex_prime - (gex_prime[idx_gex_prime] & 0x80 ? 1 : 0);
 
-    exchangeBuf.writeUInt32BE(len_gex_gen, bp, true);
+    exchangeBuf.writeUInt32BE(len_gex_gen, bp);
     bp += 4;
     if (gex_gen[idx_gex_gen] & 0x80)
       exchangeBuf[bp++] = 0;
@@ -5121,21 +5121,21 @@ function KEXDH_REPLY(self, e) { // Server
     bp += len_gex_gen - (gex_gen[idx_gex_gen] & 0x80 ? 1 : 0);
   }
 
-  exchangeBuf.writeUInt32BE(len_pubkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_pubkey, bp);
   bp += 4;
   if (e[0] & 0x80)
     exchangeBuf[bp++] = 0;
   e.copy(exchangeBuf, bp); // e
   bp += len_pubkey - (e[0] & 0x80 ? 1 : 0);
 
-  exchangeBuf.writeUInt32BE(len_spubkey, bp, true);
+  exchangeBuf.writeUInt32BE(len_spubkey, bp);
   bp += 4;
   if (outstate.pubkey[idx_spubkey] & 0x80)
     exchangeBuf[bp++] = 0;
   outstate.pubkey.copy(exchangeBuf, bp, idx_spubkey); // f
   bp += len_spubkey - (outstate.pubkey[idx_spubkey] & 0x80 ? 1 : 0);
 
-  exchangeBuf.writeUInt32BE(len_secret, bp, true);
+  exchangeBuf.writeUInt32BE(len_secret, bp);
   bp += 4;
   if (secret[idx_secret] & 0x80)
     exchangeBuf[bp++] = 0;
@@ -5203,25 +5203,25 @@ function KEXDH_REPLY(self, e) { // Server
   buf[bp] = (!isGEX ? MESSAGE.KEXDH_REPLY : MESSAGE.KEXDH_GEX_REPLY);
   ++bp;
 
-  buf.writeUInt32BE(len_hostkey, bp, true);
+  buf.writeUInt32BE(len_hostkey, bp);
   bp += 4;
   hostkey.copy(buf, bp); // K_S
   bp += len_hostkey;
 
-  buf.writeUInt32BE(len_spubkey, bp, true);
+  buf.writeUInt32BE(len_spubkey, bp);
   bp += 4;
   if (outstate.pubkey[idx_spubkey] & 0x80)
     buf[bp++] = 0;
   outstate.pubkey.copy(buf, bp, idx_spubkey); // f
   bp += len_spubkey - (outstate.pubkey[idx_spubkey] & 0x80 ? 1 : 0);
 
-  buf.writeUInt32BE(siglen, bp, true);
+  buf.writeUInt32BE(siglen, bp);
   bp += 4;
-  buf.writeUInt32BE(hostkeyAlgo.length, bp, true);
+  buf.writeUInt32BE(hostkeyAlgo.length, bp);
   bp += 4;
   buf.write(hostkeyAlgo, bp, hostkeyAlgo.length, 'ascii');
   bp += hostkeyAlgo.length;
-  buf.writeUInt32BE(signature.length, bp, true);
+  buf.writeUInt32BE(signature.length, bp);
   bp += 4;
   signature.copy(buf, bp);
 
@@ -5304,7 +5304,7 @@ function send_(self, payload, cb) {
 
   buf = new Buffer(pktLen);
 
-  buf.writeUInt32BE(pktLen - 4, 0, true);
+  buf.writeUInt32BE(pktLen - 4, 0);
   buf[4] = padLen;
   payload.copy(buf, 5);
 
@@ -5313,7 +5313,7 @@ function send_(self, payload, cb) {
 
   if (hmac.type !== false && hmac.key) {
     mac = crypto.createHmac(SSH_TO_OPENSSL[hmac.type], hmac.key);
-    outstate.bufSeqno.writeUInt32BE(outstate.seqno, 0, true);
+    outstate.bufSeqno.writeUInt32BE(outstate.seqno, 0);
     mac.update(outstate.bufSeqno);
     mac.update(buf);
     mac = mac.digest();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,7 +57,7 @@ function readInt(buffer, start, stream, cb) {
     return false;
   }
 
-  return buffer.readUInt32BE(start, true);
+  return buffer.readUInt32BE(start);
 }
 
 function DSASigBERToBare(signature) {
@@ -135,9 +135,9 @@ function ECDSASigASN1ToSSH(signature) {
   if (r === null || s === null)
     throw new Error('Invalid signature');
   var newSig = new Buffer(4 + r.length + 4 + s.length);
-  newSig.writeUInt32BE(r.length, 0, true);
+  newSig.writeUInt32BE(r.length, 0);
   r.copy(newSig, 4);
-  newSig.writeUInt32BE(s.length, 4 + r.length, true);
+  newSig.writeUInt32BE(s.length, 4 + r.length);
   s.copy(newSig, 4 + 4 + r.length);
   return newSig;
 }
@@ -464,14 +464,14 @@ function genPublicKey(keyInfo) {
                              + 4 + n.length
                              + 4 + e.length);
 
-      publicKey.writeUInt32BE(7, 0, true);
+      publicKey.writeUInt32BE(7, 0);
       publicKey.write('ssh-rsa', 4, 7, 'ascii');
 
       i = 4 + 7;
-      publicKey.writeUInt32BE(e.length, i, true);
+      publicKey.writeUInt32BE(e.length, i);
       e.copy(publicKey, i += 4);
 
-      publicKey.writeUInt32BE(n.length, i += e.length, true);
+      publicKey.writeUInt32BE(n.length, i += e.length);
       n.copy(publicKey, i += 4);
     } else if (keyInfo.type === 'dss') { // DSA
       // prime (p) -- integer
@@ -516,20 +516,20 @@ function genPublicKey(keyInfo) {
                              + 4 + g.length
                              + 4 + y.length);
 
-      publicKey.writeUInt32BE(7, 0, true);
+      publicKey.writeUInt32BE(7, 0);
       publicKey.write('ssh-dss', 4, 7, 'ascii');
 
       i = 4 + 7;
-      publicKey.writeUInt32BE(p.length, i, true);
+      publicKey.writeUInt32BE(p.length, i);
       p.copy(publicKey, i += 4);
 
-      publicKey.writeUInt32BE(q.length, i += p.length, true);
+      publicKey.writeUInt32BE(q.length, i += p.length);
       q.copy(publicKey, i += 4);
 
-      publicKey.writeUInt32BE(g.length, i += q.length, true);
+      publicKey.writeUInt32BE(g.length, i += q.length);
       g.copy(publicKey, i += 4);
 
-      publicKey.writeUInt32BE(y.length, i += g.length, true);
+      publicKey.writeUInt32BE(y.length, i += g.length);
       y.copy(publicKey, i += 4);
     } else { // ECDSA
       d = asnReader.readString(Ber.OctetString, true);
@@ -570,13 +570,13 @@ function genPublicKey(keyInfo) {
                              + 4 + 8 // <curve name>
                              + 4 + Q.length);
 
-      publicKey.writeUInt32BE(19, 0, true);
+      publicKey.writeUInt32BE(19, 0);
       publicKey.write('ecdsa-sha2-' + ecCurveName, 4, 19, 'ascii');
 
-      publicKey.writeUInt32BE(8, 23, true);
+      publicKey.writeUInt32BE(8, 23);
       publicKey.write(ecCurveName, 27, 8, 'ascii');
 
-      publicKey.writeUInt32BE(Q.length, 35, true);
+      publicKey.writeUInt32BE(Q.length, 35);
       Q.copy(publicKey, 39);
     }
   } else if (keyInfo.public) {
@@ -602,7 +602,7 @@ function genPublicKey(keyInfo) {
                      || publicKey[10] !== 115)))) {
       var newPK = new Buffer(4 + 7 + publicKey.length);
       publicKey.copy(newPK, 11);
-      newPK.writeUInt32BE(7, 0, true);
+      newPK.writeUInt32BE(7, 0);
       if (keyInfo.type === 'rsa')
         newPK.write('ssh-rsa', 4, 7, 'ascii');
       else
@@ -679,15 +679,15 @@ function verifyPPKMAC(keyInfo, passphrase, privateKey) {
                            + 4 + privlen);
   var p = 0;
 
-  macdata.writeUInt32BE(typelen, p, true);
+  macdata.writeUInt32BE(typelen, p);
   macdata.write(keyInfo.fulltype, p += 4, typelen, 'ascii');
-  macdata.writeUInt32BE(enclen, p += typelen, true);
+  macdata.writeUInt32BE(enclen, p += typelen);
   macdata.write(enc, p += 4, enclen, 'ascii');
-  macdata.writeUInt32BE(commlen, p += enclen, true);
+  macdata.writeUInt32BE(commlen, p += enclen);
   macdata.write(keyInfo.comment, p += 4, commlen, 'utf8');
-  macdata.writeUInt32BE(publen, p += commlen, true);
+  macdata.writeUInt32BE(publen, p += commlen);
   pub.copy(macdata, p += 4);
-  macdata.writeUInt32BE(privlen, p += publen, true);
+  macdata.writeUInt32BE(privlen, p += publen);
   privateKey.copy(macdata, p += 4);
 
   if (typeof passphrase !== 'string')
@@ -795,7 +795,7 @@ function readString(buffer, start, encoding, stream, cb, maxLen) {
     return false;
   }
 
-  len = buffer.readUInt32BE(start, true);
+  len = buffer.readUInt32BE(start);
   if (len > (maxLen || MAX_STRING_LEN) || left < (4 + len)) {
     stream && stream._cleanup(cb);
     return false;


### PR DESCRIPTION
The support for `noAssert` dropped in v.10.x and the argument has
no effect anymore. This will remove it therefore.

Refs: https://github.com/nodejs/node/pull/18395