### PR TITLE
SSH2Stream: Add openssh_authAgent method

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,8 @@ SSH2Stream methods
 
 * **openssh_forwardedStreamLocal**(< _integer_ >channel, < _integer_ >initWindow, < _integer_ >maxPacket, < _object_ >info) - _boolean_ - Writes an forwarded-streamlocal@openssh.com channel open packet. `info` must contain `socketPath`. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 
+* **openssh_authAgent**(< _integer_ >channel, < _integer_ >initWindow, < _integer_ >maxPacket) - _boolean_ - Writes an auth-agent@openssh.com channel open packet. Returns `false` if you should wait for the `continue` event before sending any more traffic.
+
 * **exitStatus**(< _integer_ >channel, < _integer_ >exitCode) - _boolean_ - Writes an exit status channel request packet. Returns `false` if you should wait for the `continue` event before sending any more traffic.
 
 * **exitSignal**(< _integer_ >channel, < _string_ >signalName, < _boolean_ >coreDumped, < _string_ >errorMessage) - _boolean_ - Writes an exit signal channel request packet. Returns `false` if you should wait for the `continue` event before sending any more traffic.

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -1984,6 +1984,28 @@ SSH2Stream.prototype.openssh_forwardedStreamLocal = function(chan, initWindow,
              + ', forwarded-streamlocal@openssh.com)');
   return send(this, buf);
 };
+SSH2Stream.prototype.openssh_authAgent = function(chan, initWindow, maxPacket) {
+  if (!this.server)
+    throw new Error('Server-only method called in client mode');
+
+  var buf = Buffer.allocUnsafe(1 + 4 + 22 + 4 + 4 + 4);
+
+  buf[0] = MESSAGE.CHANNEL_OPEN;
+
+  writeUInt32BE(buf, 22, 1);
+  buf.write('auth-agent@openssh.com', 5, 22, 'ascii');
+
+  writeUInt32BE(buf, chan, 27);
+
+  writeUInt32BE(buf, initWindow, 31);
+
+  writeUInt32BE(buf, maxPacket, 35);
+
+  this.debug('DEBUG: Outgoing: Writing CHANNEL_OPEN ('
+             + chan
+             + ', auth-agent@openssh.com)');
+  return send(this, buf);
+};
 SSH2Stream.prototype.exitStatus = function(chan, status) {
   if (!this.server)
     throw new Error('Server-only method called in client mode');


### PR DESCRIPTION
Hi! I didn't find a way to open authentication agent channel on server stream which has been a major drawback for my application to utilize SSH. I'd be happy to implement agent forwarding feature in [mscdex/ssh2](mscdex/ssh2) once this gets merged.