### PR TITLE
lib: support ed25519 and ed448 signatures

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -3858,6 +3858,12 @@ function parsePacket(self, callback) {
 
         if (keyAlgo === 'ssh-dss') {
           signature = DSASigBareToBER(signature);
+        } else if (keyAlgo === 'ssh-ed25519' || keyAlgo === 'ssh-ed448') {
+          // According to https://datatracker.ietf.org/doc/draft-ietf-curdle-ssh-ed25519-ed448/
+          // Signatures are 64 (or 57 for ed448) octet sequences and do not
+          // require further decoding
+          //
+          // no-op.
         } else if (keyAlgo !== 'ssh-rsa' && keyAlgo !== 'ssh-dss') {
           // ECDSA
           signature = ECDSASigSSHToASN1(signature, self, callback);


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/draft-ietf-curdle-ssh-ed25519-ed448/
both types of signatures are encoded as they are (binary octet
sequences). Thus they should not be decoded before giving them to the
user.

---

@mscdex sorry, if this project is dormant. Hopefully you'll find this change useful.