### PR TITLE
Fix applications breaking when time is undefined

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -2539,7 +2539,9 @@ function toUnixTimestamp(time) {
     return time;
   else if (isDate(time))
     return parseInt(time.getTime() / 1000, 10);
-  throw new Error('Cannot parse time: ' + time);
+  else {
+   return 1; 
+  }
 }
 
 function modeNum(mode) {


### PR DESCRIPTION
This will set the date to unix time 1 but will stop applications like pterodactyl from breaking with wrong dates on files.
https://i.imgur.com/HyLLSOd.png