### PR TITLE
fix: key is not defined

### DIFF
--- a/lib/keyParser.js
+++ b/lib/keyParser.js
@@ -776,7 +776,7 @@ OpenSSH_Old_Private.prototype = BaseKey;
                             .digest();
           while (cipherKey.length < encInfo.keyLen) {
             cipherKey = combineBuffers(
-              key,
+              cipherKey,
               (createHash('md5')
                 .update(cipherKey)
                 .update(passphrase)


### PR DESCRIPTION
The variable `key` is not been defined anywhere. I think it should be `cipherKey`.

PS: `OpenSSH_Private.parse` returns an array which could cause a TypeError `privKey.getPrivatePEM is not a function` at [ssh2/lib/client.js#L233](https://github.com/mscdex/ssh2/blob/fbea9a71b285a0a2591da6e4701d9181cd733366/lib/client.js#L233). I have no idea how to fix this.