### PR TITLE
Add fileSize to fastGet options (skips fstat/stat calls if provided)

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -991,6 +991,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
   //var preserve = false;
   var onstep;
   var mode;
+  var fileSize;
 
   if (typeof opts === 'function') {
     cb = opts;
@@ -1003,6 +1004,10 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
         && opts.chunkSize > 0
         && !isNaN(opts.chunkSize))
       chunkSize = opts.chunkSize;
+      if (typeof opts.fileSize === 'number'
+        && opts.fileSize > 0
+        && !isNaN(opts.fileSize))
+      fileSize = opts.fileSize;
     if (typeof opts.step === 'function')
       onstep = opts.step;
     //preserve = (opts.preserve ? true : false);
@@ -1055,7 +1060,12 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
 
     srcHandle = sourceHandle;
 
-    src.fstat(srcHandle, function tryStat(err, attrs) {
+    if( !fileSize )
+      src.fstat(srcHandle, tryStat);
+    else
+      tryStat(null, {size: fileSize});
+
+    function tryStat(err, attrs) {
       if (err) {
         if (src !== fs) {
           // Try stat() for sftp servers that may not support fstat() for
@@ -1170,7 +1180,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
           psrc = 0;
         }
       });
-    });
+    }
   });
 }
 SFTPStream.prototype.fastGet = function(remotePath, localPath, opts, cb) {


### PR DESCRIPTION
I have run into the issue, that is described  in:
https://github.com/mscdex/ssh2/issues/611

In our case fastGet is called inside readdir callback. We have file attributes available. It makes sense to pass file size as an option to fastGet.



