### PR TITLE
Advance cursor by amount read

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -2868,11 +2868,11 @@ ReadStream.prototype._read = function(n) {
       b = thisPool.slice(start, start + bytesRead);
     }
 
+    // Move the pool positions, and internal position for reading.
+    this.pos += bytesRead;
+
     this.push(b);
   });
-
-  // Move the pool positions, and internal position for reading.
-  this.pos += toRead;
 
   pool.used = roundUpToMultipleOf8(pool.used + toRead);
 };


### PR DESCRIPTION
Currently the read cursor advances by the number of bytes requested. If the server returns fewer bytes, part of the file is missed. Instead advance the cursor by the amount of bytes read.

Fixes https://github.com/mscdex/ssh2/issues/739