### PR TITLE
SSH2Stream: fix queued data handling on rekey

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -713,7 +713,7 @@ SSH2Stream.prototype._transform = function(chunk, encoding, callback, decomp) {
         if (++instate.seqno > MAX_SEQNO)
           instate.seqno = 0;
 
-        instate.rekeyQueue.push(seqno, instate.payload);
+        instate.rekeyQueue.push([seqno, instate.payload]);
       }
 
       instate.status = IN_PACKETBEFORE;


### PR DESCRIPTION
I've tried to add key re-exchange support for a project I'm working on and ran into an uncaught error:
```
./ssh2-streams/lib/ssh.js:3244
  var type = payload[0];
                    ^

TypeError: Cannot read property '0' of undefined
```

The error happens when queued data is being processed after new keys have been established. The code that fetches packets from a queue looks like this:
```javascript
instate.seqno = queue[q][0];
instate.payload = queue[q][1];
```
So supposedly items in the queue should be arrays of size 2 but they weren't:
```javascript
instate.rekeyQueue.push(seqno, instate.payload);
```
So I fixed that. I used OpenSSH client and this little script to reproduce the issue:
```javascript
var fs = require('fs');
var ssh2 = require('ssh2');

new ssh2.Server({
  hostKeys: [fs.readFileSync('host.key')]
}, function(client) {
  console.log('Client connected!');

  client.on('authentication', function(ctx) {
    ctx.accept();
  }).on('ready', function() {
    console.log('Client authenticated!');

    client.on('session', function(accept, reject) {
      var session = accept();

      client.rekey(); // Error happens here

      });
  }).on('end', function() {
    console.log('Client disconnected');
  });
}).listen(2222, '127.0.0.1', function() {
  console.log('Listening on port ' + this.address().port);
});

```