### PR TITLE
try add diffie-hellman-group14/15/16/17/18

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -216,7 +216,13 @@ var DEFAULT_KEX = [
   // https://tools.ietf.org/html/rfc4419#section-4
   'diffie-hellman-group-exchange-sha256',
 
-  'diffie-hellman-group14-sha1' // REQUIRED
+  'diffie-hellman-group14-sha1', // REQUIRED
+
+  'diffie-hellman-group14-sha256',
+  'diffie-hellman-group15-sha512',
+  'diffie-hellman-group16-sha512',
+  'diffie-hellman-group17-sha512',
+  'diffie-hellman-group18-sha512'
 ];
 var SUPPORTED_KEX = [
   // https://tools.ietf.org/html/rfc4419#section-4

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -634,14 +634,14 @@ SSH2Stream.prototype._transform = function(chunk, encoding, callback, decomp) {
           msgPacket += '(enqueued) ';
 
         if (ptype === MESSAGE.KEXDH_INIT) {
-          if (kexdh === 'group')
+          if (kexdh.startsWith('group'))
             msgPktType = 'KEXDH_INIT';
           else if (kexdh[0] === 'e')
             msgPktType = 'KEXECDH_INIT';
           else
             msgPktType = 'KEXDH_GEX_REQUEST';
         } else if (ptype === MESSAGE.KEXDH_REPLY) {
-          if (kexdh === 'group')
+          if (kexdh.startsWith('group'))
             msgPktType = 'KEXDH_REPLY';
           else if (kexdh[0] === 'e')
             msgPktType = 'KEXECDH_REPLY';
@@ -2558,14 +2558,18 @@ function check_KEXINIT(self, init, firstFollows) {
   else
     val = instate.decompress.type = clientList[i];
   debug('DEBUG: Server->Client compression algorithm: ' + val);
-
+  var m;
   switch (kex_algorithm) {
     case 'diffie-hellman-group1-sha1':
-      state.kexdh = 'group';
+      state.kexdh = 'group-sha1';
       state.kex = crypto.getDiffieHellman('modp2');
       break;
     case 'diffie-hellman-group14-sha1':
-      state.kexdh = 'group';
+      state.kexdh = 'group-sha1';
+      state.kex = crypto.getDiffieHellman('modp14');
+      break;
+    case 'diffie-hellman-group14-sha256':
+      state.kexdh = 'group-sha256';
       state.kex = crypto.getDiffieHellman('modp14');
       break;
     case 'ecdh-sha2-nistp256':
@@ -2589,6 +2593,14 @@ function check_KEXINIT(self, init, firstFollows) {
       // group exchange was used before the re-key. This ensures that we send
       // the right DH packet after the KEXINIT exchange
       state.kex = undefined;
+      if (m = kex_algorithm.match(/diffie-hellman-group(\d+)-sha(\d+)/)) {
+        var _group = m[1], _sha = m[2]
+        if (_sha == '512' && (['14', '15', '16', '17', '18'].indexOf(_group) != -1)) {
+          state.kexdh = 'group-sha512';
+          state.kex = crypto.getDiffieHellman('modp' + _group);
+        }
+        
+      }
   }
 
   if (state.kex) {
@@ -2737,8 +2749,9 @@ function onKEXDH_REPLY(self, info, verifiedHost) { // Client
   }
 
   var hashAlgo;
-  if (state.kexdh === 'group')
-    hashAlgo = 'sha1';
+  var _hash = state.kexdh.match(/group-(sha\d+)/);
+  if (_hash)
+    hashAlgo = _hash[1];
   else
     hashAlgo = RE_KEX_HASH.exec(state.kexdh)[1];
   var hash = crypto.createHash(hashAlgo);
@@ -2950,8 +2963,9 @@ function onNEWKEYS(self) { // Client/Server
   var p = 0;
 
   var dhHashAlgo;
-  if (state.kexdh === 'group')
-    dhHashAlgo = 'sha1';
+  var _hash = state.kexdh.match(/group-(sha\d+)/);
+  if (_hash)
+    dhHashAlgo = _hash[1];
   else
     dhHashAlgo = RE_KEX_HASH.exec(state.kexdh)[1];
 
@@ -4846,8 +4860,9 @@ function KEXDH_REPLY(self, e) { // Server
   }
 
   var hashAlgo;
-  if (state.kexdh === 'group')
-    hashAlgo = 'sha1';
+  var _hash = state.kexdh.match(/group-(sha\d+)/);
+  if (_hash) 
+    hashAlgo = _hash[1];
   else
     hashAlgo = RE_KEX_HASH.exec(state.kexdh)[1];
 


### PR DESCRIPTION
Hi, 
I'm using vs-code to try to connect to a docker server which only allows `curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512` 

I'm trying to add diffie-hellman-group14-sha256 and diffie-hellman-group15/16/17/18-sha512. 

Not sure if what I'm doing is correct (how should I test it?) but after reading the code I think it should be something like this.

What I did:
1. changing `xxx === 'group'` to `xxx.startsWith('group')`
2. for sha1, set `kexdh = 'group-sha1'`
3. matching `diffie-hellman-group14-sha256`, set `kexdh = 'group-sha256'` and `kex = crypto.getDiffieHellman('modp14')`
4. matching `/diffie-hellman-group(\d+)-sha(\d+)/`, set `kexdh = 'group-sha512'` and `kex = crypto.getDiffieHellman('modp' + match[2])`
5. retrive `sha-xxx` for `hashAlgo`