### PR TITLE
Fix bigIntToBuffer for numbers that start 0x9

### DIFF
--- a/lib/keyParser.js
+++ b/lib/keyParser.js
@@ -168,10 +168,13 @@ var genOpenSSLRSAPriv = (function() {
     if ((hex.length & 1) !== 0) {
       hex = '0' + hex;
     } else {
-      var sigbit = hex.charCodeAt(0);
+      var sighex = hex.charCodeAt(0);
+
+      const ASCII_0 = 0x30;
+      const ASCII_7 = 0x37;
       // BER/DER integers require leading zero byte to denote a positive value
       // when first byte >= 0x80
-      if (sigbit === 56 || (sigbit >= 97 && sigbit <= 102))
+      if (sighex < ASCII_0 || sighex > ASCII_7)
         hex = '00' + hex;
     }
     return Buffer.from(hex, 'hex');


### PR DESCRIPTION
Numbers that start 0x9... did not have '00' prepended.

Fixes #163

Probably a good idea to add a unit test for this function! I don't have time at the moment though, sorry.