### PR TITLE
SFTPStream: add more error codes

### DIFF
--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -32,7 +32,22 @@ var STATUS_CODE = {
   BAD_MESSAGE: 5,
   NO_CONNECTION: 6,
   CONNECTION_LOST: 7,
-  OP_UNSUPPORTED: 8
+  OP_UNSUPPORTED: 8,
+  INVALID_HANDLE: 9,
+  NO_SUCH_PATH: 10,
+  FILE_ALREADY_EXISTS: 11,
+  WRITE_PROTECT: 12,
+  NO_MEDIA: 13,
+  NO_SPACE_ON_FILESYSTEM: 14,
+  QUOTA_EXCEEDED: 15,
+  UNKNOWN_PRINCIPLE: 16, /* Initial mis-spelling */
+  UNKNOWN_PRINCIPAL: 16,
+  LOCK_CONFlICT: 17, /* Initial mis-spelling */
+  LOCK_CONFLICT: 17,
+  DIR_NOT_EMPTY: 18,
+  NOT_A_DIRECTORY: 19,
+  INVALID_FILENAME: 20,
+  LINK_LOOP: 21
 };
 Object.keys(STATUS_CODE).forEach(function(key) {
   STATUS_CODE[STATUS_CODE[key]] = key;
@@ -46,7 +61,20 @@ var STATUS_CODE_STR = {
   5: 'Bad message',
   6: 'No connection',
   7: 'Connection lost',
-  8: 'Operation unsupported'
+  8: 'Operation unsupported',
+  9: 'Invalid handle',
+  10: 'No such path',
+  11: 'File already exists',
+  12: 'Write protected',
+  13: 'No media',
+  14: 'No space on filesystem',
+  15: 'Quota exceeded',
+  16: 'Unknown principal',
+  17: 'Lock conflict',
+  18: 'Dir not empty',
+  19: 'Not a directory',
+  20: 'Invalid filename',
+  21: 'Operation unsupported'
 };
 SFTPStream.STATUS_CODE = STATUS_CODE;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh2-streams",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "SSH2 and SFTP(v3) client/server protocol streams for node.js",
   "main": "./index",


### PR DESCRIPTION
A small update to add more error codes. The codes are copied straight from `libssh2_sftp.h`